### PR TITLE
Improve: support multiple dynamic sections in a group

### DIFF
--- a/Demos/Basic-ObjC/Basic-ObjC/Assets/forms.json
+++ b/Demos/Basic-ObjC/Basic-ObjC/Assets/forms.json
@@ -260,6 +260,12 @@
           "type":"dynamic",
           "action_title":"ADD COMPANY ✛",
           "fields":null
+        },
+        {
+          "id":"contacts",
+          "type":"dynamic",
+          "action_title":"ADD CONTACT ✛",
+          "fields":null
         }
       ]
     }
@@ -272,8 +278,7 @@
         "fields":[
           {
             "id":"companies[:index].name",
-            "title":"Name",
-            "subtitle":"Hyper",
+            "title":"Company Name",
             "type":"name",
             "validations":{
               "required":true,
@@ -295,6 +300,42 @@
           },
           {
             "id":"companies[:index].remove",
+            "title":"Remove",
+            "type":"button",
+            "size":{
+              "width":20,
+              "height":1
+            }
+          }
+        ]
+      },
+      {
+        "id":"contacts",
+        "fields":[
+          {
+            "id":"contacts[:index].name",
+            "title":"Contact name",
+            "type":"name",
+            "validations":{
+              "required":true,
+              "min_length":2
+            },
+            "size":{
+              "width":50,
+              "height":1
+            }
+          },
+          {
+            "id":"contacts[:index].phone_number",
+            "title":"Phone number",
+            "type":"number",
+            "size":{
+              "width":30,
+              "height":1
+            }
+          },
+          {
+            "id":"contacts[:index].remove",
             "title":"Remove",
             "type":"button",
             "size":{

--- a/Demos/Basic-ObjC/Podfile
+++ b/Demos/Basic-ObjC/Podfile
@@ -2,4 +2,4 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '7.0'
 
-pod 'Form', git: 'https://github.com/hyperoslo/Form', branch: 'feature/dynamic-sections'
+pod 'Form', git: 'https://github.com/hyperoslo/Form', branch: 'improve/support-multiple-dynamic-sections-in-a-group'

--- a/Demos/Basic-ObjC/Podfile.lock
+++ b/Demos/Basic-ObjC/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Form (0.122):
+  - Form (0.123):
     - Hex
     - HYPImagePicker
     - HYPMathParser
@@ -34,20 +34,20 @@ PODS:
   - UIScreen-HYPLiveBounds (1.3)
 
 DEPENDENCIES:
-  - Form (from `https://github.com/hyperoslo/Form`, branch `feature/dynamic-sections`)
+  - Form (from `https://github.com/hyperoslo/Form`, branch `improve/support-multiple-dynamic-sections-in-a-group`)
 
 EXTERNAL SOURCES:
   Form:
-    :branch: feature/dynamic-sections
+    :branch: improve/support-multiple-dynamic-sections-in-a-group
     :git: https://github.com/hyperoslo/Form
 
 CHECKOUT OPTIONS:
   Form:
-    :commit: 3444ace1a17e739eb7272dc257e9ecab8e7c952a
+    :commit: 62598cfcca70d9127446de2b217074f6ad65996a
     :git: https://github.com/hyperoslo/Form
 
 SPEC CHECKSUMS:
-  Form: 21096648e193959de35d57c39be742afea555a5f
+  Form: d2f0cd36e26cd36c37569ac7a2969ca6f992ee22
   Hex: 26fa055654eb713e45bb9771046a2d26c0c086f6
   HYPImagePicker: 501c6cbd2c758215fc85fffca1d834b69f5eef3c
   HYPMathParser: d5542b17ea598bfedfa7d990c6e78a84bfddae16

--- a/Demos/Basic-ObjC/Podfile.lock
+++ b/Demos/Basic-ObjC/Podfile.lock
@@ -43,7 +43,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Form:
-    :commit: 62598cfcca70d9127446de2b217074f6ad65996a
+    :commit: 8a7a2a6e343b597801d79560b3bbedd29177b8b0
     :git: https://github.com/hyperoslo/Form
 
 SPEC CHECKSUMS:

--- a/Form.podspec
+++ b/Form.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Form"
-  s.version = "0.122"
+  s.version = "0.123"
   s.summary = "JSON driven forms"
   s.homepage = "https://github.com/hyperoslo/Form"
   s.license = {

--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -904,8 +904,16 @@
 
     [templateSectionDictionary setValue:[fields copy] forKey:@"fields"];
 
+    FORMSection *actionSection = [self sectionWithID:sectionTemplateID];
+    NSInteger sectionPosition = [actionSection.position integerValue];
+    for (FORMSection *currentSection in form.sections) {
+        if ([currentSection.sectionID hyp_containsString:sectionTemplateID]) {
+            sectionPosition++;
+        }
+    }
+
     FORMSection *section = [[FORMSection alloc] initWithDictionary:templateSectionDictionary
-                                                          position:index + 1
+                                                          position:sectionPosition
                                                           disabled:NO
                                                  disabledFieldsIDs:nil
                                                      isLastSection:YES];
@@ -917,7 +925,14 @@
         }
     }
 
-    [form.sections addObject:section];
+    NSInteger sectionIndex = [section.position integerValue];
+    [form.sections insertObject:section atIndex:sectionIndex];
+
+    [form.sections enumerateObjectsUsingBlock:^(FORMSection *currentSection, NSUInteger idx, BOOL *stop) {
+        if (idx > sectionIndex) {
+            currentSection.position = @([currentSection.position integerValue] + 1);
+        }
+    }];
 
     if (collectionView) {
         [self sectionWithID:section.sectionID completion:^(FORMSection *section, NSArray *indexPaths) {

--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -923,6 +923,10 @@
         [self sectionWithID:section.sectionID completion:^(FORMSection *section, NSArray *indexPaths) {
             if (indexPaths) {
                 [collectionView insertItemsAtIndexPaths:indexPaths];
+
+                [collectionView scrollToItemAtIndexPath:indexPaths.lastObject
+                                       atScrollPosition:UICollectionViewScrollPositionTop
+                                               animated:YES];
             }
         }];
     }

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -513,6 +513,12 @@ static const CGFloat FORMDispatchTime = 0.05f;
             NSDictionary *parsed = [field.fieldID hyp_parseRelationship];
             NSString *sectionID = [NSString stringWithFormat:@"%@[%@]", [parsed objectForKey:@"relationship"], [parsed objectForKey:@"index"]];
             [self.formsManager sectionWithID:sectionID completion:^(FORMSection *section, NSArray *indexPaths) {
+                for (FORMSection *currentSection in section.form.sections) {
+                    if ([currentSection.position integerValue] > [section.position integerValue]) {
+                        currentSection.position = @([currentSection.position integerValue] - 1);
+                    }
+                }
+
                 [self.formsManager.hiddenSections setObject:section forKey:sectionID];
                 FORMGroup *group = section.form;
                 [group.sections removeObject:section];

--- a/Source/Models/FORMSection.m
+++ b/Source/Models/FORMSection.m
@@ -54,7 +54,7 @@
         [fields addObject:field];
     }
 
-    if (!isLastSection) {
+    if (!isLastSection || _type == FORMSectionTypeDynamic) {
         FORMField *field = [FORMField new];
         field.sectionSeparator = YES;
         field.position = @(fields.count);

--- a/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
@@ -357,9 +357,34 @@
     XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:14 inSection:0]);
 }
 
-- (void)testMultipleAdditionAndRemovalsOfDynamicSections
+- (void)testUpdatedSectionPositionWhenRemovingDynamicSections
 {
+    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"dynamic.json"
+                                                             inBundle:[NSBundle bundleForClass:[self class]]];
 
+    FORMDataSource *dataSource = [[FORMDataSource alloc] initWithJSON:JSON
+                                                       collectionView:nil
+                                                               layout:nil
+                                                               values:nil
+                                                             disabled:YES];
+
+    FORMField *addField = [dataSource fieldWithID:@"companies.add" includingHiddenFields:NO];
+    XCTAssertNotNil(addField);
+
+    [dataSource fieldCell:nil updatedWithField:addField];
+
+    FORMField *removeField = [dataSource fieldWithID:@"companies[0].remove" includingHiddenFields:NO];
+    XCTAssertNotNil(removeField);
+
+    FORMSection *section = [dataSource sectionWithID:@"companies[0]"];
+    XCTAssertNotNil(section);
+    XCTAssertEqualObjects(section.position, @2);
+
+    [dataSource fieldCell:nil updatedWithField:removeField];
+
+    section = [dataSource sectionWithID:@"personal-details-1"];
+    XCTAssertEqualObjects(section.position, @2);
+    XCTAssertNotNil(section);
 }
 
 @end

--- a/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
@@ -314,7 +314,7 @@
     XCTAssertEqualObjects(field.fieldValue, @"4555666");
 }
 
-- (void)testAddingAndRemovingMultipleDynamicFields
+- (void)testAddingAndRemovingMultipleDynamicSections
 {
     NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"dynamic.json"
                                                              inBundle:[NSBundle bundleForClass:[self class]]];
@@ -355,6 +355,11 @@
     }];
 
     XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:14 inSection:0]);
+}
+
+- (void)testMultipleAdditionAndRemovalsOfDynamicSections
+{
+
 }
 
 @end

--- a/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
@@ -314,4 +314,39 @@
     XCTAssertEqualObjects(field.fieldValue, @"4555666");
 }
 
+- (void)testAddingAndRemovingMultipleDynamicFields
+{
+    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"dynamic.json"
+                                                             inBundle:[NSBundle bundleForClass:[self class]]];
+
+    FORMDataSource *dataSource = [[FORMDataSource alloc] initWithJSON:JSON
+                                                       collectionView:nil
+                                                               layout:nil
+                                                               values:nil
+                                                             disabled:YES];
+
+    FORMField *field = [dataSource fieldWithID:@"companies.add" includingHiddenFields:NO];
+    XCTAssertNotNil(field);
+
+    [dataSource fieldCell:nil updatedWithField:field];
+
+    __block NSIndexPath *fieldIndexPath;
+    [dataSource fieldWithID:@"companies[0].name" includingHiddenFields:NO completion:^(FORMField *field, NSIndexPath *indexPath) {
+        fieldIndexPath = indexPath;
+    }];
+
+    XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:4 inSection:0]);
+
+    field = [dataSource fieldWithID:@"contacts.add" includingHiddenFields:NO];
+    XCTAssertNotNil(field);
+
+    [dataSource fieldCell:nil updatedWithField:field];
+
+    [dataSource fieldWithID:@"contacts[0].name" includingHiddenFields:NO completion:^(FORMField *field, NSIndexPath *indexPath) {
+        fieldIndexPath = indexPath;
+    }];
+
+    XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:11 inSection:0]);
+}
+
 @end

--- a/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Tests/Tests/HYPFormsCollectionViewDataSourceTests.m
@@ -337,6 +337,14 @@
 
     XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:4 inSection:0]);
 
+    [dataSource fieldCell:nil updatedWithField:field];
+
+    [dataSource fieldWithID:@"companies[1].name" includingHiddenFields:NO completion:^(FORMField *field, NSIndexPath *indexPath) {
+        fieldIndexPath = indexPath;
+    }];
+
+    XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:7 inSection:0]);
+
     field = [dataSource fieldWithID:@"contacts.add" includingHiddenFields:NO];
     XCTAssertNotNil(field);
 
@@ -346,7 +354,7 @@
         fieldIndexPath = indexPath;
     }];
 
-    XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:11 inSection:0]);
+    XCTAssertEqualObjects(fieldIndexPath, [NSIndexPath indexPathForRow:14 inSection:0]);
 }
 
 @end

--- a/Tests/Tests/JSONs/dynamic.json
+++ b/Tests/Tests/JSONs/dynamic.json
@@ -10,10 +10,9 @@
             {
               "id":"name",
               "title":"Name",
-              "subtitle":"This is your name!",
               "type":"name",
               "size":{
-                "width":30,
+                "width":100,
                 "height":1
               }
             }
@@ -23,6 +22,26 @@
           "id":"companies",
           "type":"dynamic",
           "action_title":"ADD COMPANY ✛",
+          "fields":null
+        },
+        {
+          "id":"personal-details-1",
+          "fields":[
+            {
+              "id":"email",
+              "title":"Email",
+              "type":"email",
+              "size":{
+                "width":100,
+                "height":1
+              }
+            }
+          ]
+        },
+        {
+          "id":"contacts",
+          "type":"dynamic",
+          "action_title":"ADD CONTACT ✛",
           "fields":null
         }
       ]
@@ -67,6 +86,42 @@
             "id":"companies[:index].remove",
             "title":"Remove",
             "type":"remove",
+            "size":{
+              "width":20,
+              "height":1
+            }
+          }
+        ]
+      },
+      {
+        "id":"contacts",
+        "fields":[
+          {
+            "id":"contacts[:index].name",
+            "title":"Contact name",
+            "type":"name",
+            "validations":{
+              "required":true,
+              "min_length":2
+            },
+            "size":{
+              "width":50,
+              "height":1
+            }
+          },
+          {
+            "id":"contacts[:index].phone_number",
+            "title":"Phone number",
+            "type":"number",
+            "size":{
+              "width":30,
+              "height":1
+            }
+          },
+          {
+            "id":"contacts[:index].remove",
+            "title":"Remove",
+            "type":"button",
             "size":{
               "width":20,
               "height":1


### PR DESCRIPTION
Adding dynamic sections works perfectly, when a section gets added the position of the sections bellow will be updated `+1`.

But when removing dynamic sections the sections bellow weren't been decreased by one `-1`.

This PR fixes that.