### PR TITLE
Fix: dynamic fields with inital values bug

### DIFF
--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -200,7 +200,7 @@
                             FORMField *field = [self fieldWithID:valueID includingHiddenFields:YES];
                             field.value = [self.values objectForKey:valueID];
                         } else {
-                            [self insertTemplateSectionWithID:sectionTemplateID intoCollectionView:nil usingForm:form valueID:valueID];
+                            [self insertTemplateSectionWithID:sectionTemplateID intoCollectionView:nil usingForm:form];
                         }
                     }
                 }
@@ -902,11 +902,6 @@
 
 - (void)insertTemplateSectionWithID:(NSString *)sectionTemplateID intoCollectionView:(UICollectionView *)collectionView usingForm:(FORMGroup *)form
 {
-    [self insertTemplateSectionWithID:sectionTemplateID intoCollectionView:collectionView usingForm:form valueID:nil];
-}
-
-- (void)insertTemplateSectionWithID:(NSString *)sectionTemplateID intoCollectionView:(UICollectionView *)collectionView usingForm:(FORMGroup *)form valueID:(NSString *)valueID
-{
     FORMSection *foundSection;
     for (FORMSection *aSection in form.sections) {
         if ([aSection.sectionID isEqualToString:sectionTemplateID]) {
@@ -952,10 +947,8 @@
                                                          isLastSection:YES];
         section.form = form;
 
-        if (valueID) {
-            for (FORMField *field in section.fields) {
-                field.value = [self.values objectForKey:valueID];
-            }
+        for (FORMField *field in section.fields) {
+            field.value = [self.values andy_valueForKey:field.fieldID];
         }
 
         NSInteger sectionIndex = [section.position integerValue];

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -57,9 +57,9 @@
 		1492C05A1A9F740900D80D91 /* dynamic.json in Resources */ = {isa = PBXBuildFile; fileRef = 1492C0591A9F740900D80D91 /* dynamic.json */; };
 		149C29211A9A23DD00F88B91 /* FORMFieldValueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29111A9A23DD00F88B91 /* FORMFieldValueTests.m */; };
 		149C29221A9A23DD00F88B91 /* FORMFieldTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29121A9A23DD00F88B91 /* FORMFieldTests.m */; };
-		149C29231A9A23DD00F88B91 /* FORMCollectionViewDataSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29131A9A23DD00F88B91 /* FORMCollectionViewDataSourceTests.m */; };
+		149C29231A9A23DD00F88B91 /* FORMDataSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29131A9A23DD00F88B91 /* FORMDataSourceTests.m */; };
 		149C29241A9A23DD00F88B91 /* FORMSectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29141A9A23DD00F88B91 /* FORMSectionTests.m */; };
-		149C29251A9A23DD00F88B91 /* FORMManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29151A9A23DD00F88B91 /* FORMManagerTests.m */; };
+		149C29251A9A23DD00F88B91 /* FORMDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29151A9A23DD00F88B91 /* FORMDataTests.m */; };
 		149C29261A9A23DD00F88B91 /* FORMTargetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29161A9A23DD00F88B91 /* FORMTargetTests.m */; };
 		149C29271A9A23DD00F88B91 /* FORMTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29171A9A23DD00F88B91 /* FORMTests.m */; };
 		149C29281A9A23DD00F88B91 /* FORMPopoverFieldCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 149C29181A9A23DD00F88B91 /* FORMPopoverFieldCellTests.m */; };
@@ -178,9 +178,9 @@
 		1492C0591A9F740900D80D91 /* dynamic.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = dynamic.json; sourceTree = "<group>"; };
 		149C29111A9A23DD00F88B91 /* FORMFieldValueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMFieldValueTests.m; sourceTree = "<group>"; };
 		149C29121A9A23DD00F88B91 /* FORMFieldTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMFieldTests.m; sourceTree = "<group>"; };
-		149C29131A9A23DD00F88B91 /* FORMCollectionViewDataSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMCollectionViewDataSourceTests.m; sourceTree = "<group>"; };
+		149C29131A9A23DD00F88B91 /* FORMDataSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMDataSourceTests.m; sourceTree = "<group>"; };
 		149C29141A9A23DD00F88B91 /* FORMSectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMSectionTests.m; sourceTree = "<group>"; };
-		149C29151A9A23DD00F88B91 /* FORMManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMManagerTests.m; sourceTree = "<group>"; };
+		149C29151A9A23DD00F88B91 /* FORMDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMDataTests.m; sourceTree = "<group>"; };
 		149C29161A9A23DD00F88B91 /* FORMTargetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMTargetTests.m; sourceTree = "<group>"; };
 		149C29171A9A23DD00F88B91 /* FORMTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMTests.m; sourceTree = "<group>"; };
 		149C29181A9A23DD00F88B91 /* FORMPopoverFieldCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMPopoverFieldCellTests.m; sourceTree = "<group>"; };
@@ -434,9 +434,9 @@
 				149C29111A9A23DD00F88B91 /* FORMFieldValueTests.m */,
 				149C29121A9A23DD00F88B91 /* FORMFieldTests.m */,
 				D5DFAA1A1AA87A9B0096FBFB /* FORMFieldValidationTests.m */,
-				149C29131A9A23DD00F88B91 /* FORMCollectionViewDataSourceTests.m */,
+				149C29131A9A23DD00F88B91 /* FORMDataSourceTests.m */,
 				149C29141A9A23DD00F88B91 /* FORMSectionTests.m */,
-				149C29151A9A23DD00F88B91 /* FORMManagerTests.m */,
+				149C29151A9A23DD00F88B91 /* FORMDataTests.m */,
 				149C29161A9A23DD00F88B91 /* FORMTargetTests.m */,
 				149C29171A9A23DD00F88B91 /* FORMTests.m */,
 				149C29181A9A23DD00F88B91 /* FORMPopoverFieldCellTests.m */,
@@ -657,7 +657,7 @@
 				144A28D91A99B2CF004A9086 /* FORMPostalCodeInputValidator.m in Sources */,
 				149C29211A9A23DD00F88B91 /* FORMFieldValueTests.m in Sources */,
 				144A28D81A99B2CF004A9086 /* FORMPhoneNumberInputValidator.m in Sources */,
-				149C29231A9A23DD00F88B91 /* FORMCollectionViewDataSourceTests.m in Sources */,
+				149C29231A9A23DD00F88B91 /* FORMDataSourceTests.m in Sources */,
 				144A28E71A99B2CF004A9086 /* FORMBankAccountNumberValidator.m in Sources */,
 				149C29291A9A23DD00F88B91 /* FORMTextFieldCellTests.m in Sources */,
 				144A28DD1A99B2CF004A9086 /* FORMFieldValidation.m in Sources */,
@@ -674,7 +674,7 @@
 				149C29241A9A23DD00F88B91 /* FORMSectionTests.m in Sources */,
 				144A28EA1A99B2CF004A9086 /* FORMValidator.m in Sources */,
 				144A28DA1A99B2CF004A9086 /* FORMSocialSecurityNumberInputValidator.m in Sources */,
-				149C29251A9A23DD00F88B91 /* FORMManagerTests.m in Sources */,
+				149C29251A9A23DD00F88B91 /* FORMDataTests.m in Sources */,
 				149C29221A9A23DD00F88B91 /* FORMFieldTests.m in Sources */,
 				144A28DB1A99B2CF004A9086 /* FORMClassFactory.m in Sources */,
 				144A28BB1A99B2CF004A9086 /* FORMBaseFieldCell.m in Sources */,

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -18,11 +18,11 @@
 
 @end
 
-@interface FORMCollectionViewDataSourceTests : XCTestCase
+@interface FORMDataSourceTests : XCTestCase
 
 @end
 
-@implementation FORMCollectionViewDataSourceTests
+@implementation FORMDataSourceTests
 
 - (void)testIndexInForms
 {

--- a/Tests/Tests/FORMDataTests.m
+++ b/Tests/Tests/FORMDataTests.m
@@ -12,11 +12,11 @@
 #import "NSDictionary+ANDYSafeValue.h"
 #import "NSJSONSerialization+ANDYJSONFile.h"
 
-@interface FORMManagerTests : XCTestCase
+@interface FORMDataTests : XCTestCase
 
 @end
 
-@implementation FORMManagerTests
+@implementation FORMDataTests
 
 - (void)testFormsGeneration
 {
@@ -127,7 +127,7 @@
     [manager hideTargets:@[target]];
     section = [manager sectionWithID:@"section-2"];
     XCTAssertEqualObjects(section.position, @1);
-    
+
     target = [FORMTarget showSectionTargetWithID:@"section-1"];
     [manager showTargets:@[target]];
     section = [manager sectionWithID:@"section-2"];
@@ -338,6 +338,35 @@
     field = [manager fieldWithID:@"first_name" includingHiddenFields:YES];
 
     XCTAssertNil(field);
+}
+
+- (void)testDynamicWithInitialValues
+{
+    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"dynamic.json"
+                                                             inBundle:[NSBundle bundleForClass:[self class]]];
+
+    FORMData *data = [[FORMData alloc] initWithJSON:JSON
+                                      initialValues:@{@"companies[0].name" : @"Facebook",
+                                                      @"companies[0].phone_number" : @"1222333",
+                                                      @"companies[1].name" : @"Google"}
+                                   disabledFieldIDs:nil
+                                           disabled:NO];
+
+    FORMField *field = [data fieldWithID:@"companies[0].name" includingHiddenFields:NO];
+    XCTAssertNotNil(field);
+    XCTAssertEqualObjects(field.value, @"Facebook");
+
+    field = [data fieldWithID:@"companies[0].phone_number" includingHiddenFields:NO];
+    XCTAssertNotNil(field);
+    XCTAssertEqualObjects(field.value, @"1222333");
+
+    field = [data fieldWithID:@"companies[1].name" includingHiddenFields:NO];
+    XCTAssertNotNil(field);
+    XCTAssertEqualObjects(field.value, @"Google");
+
+    field = [data fieldWithID:@"companies[1].phone_number" includingHiddenFields:NO];
+    XCTAssertNotNil(field);
+    XCTAssertNil(field.value);
 }
 
 @end


### PR DESCRIPTION
Initializing `FORMData` with a dictionary that doesn’t contain all the elements of a template causes a crash.

```objc
FORMData *data = [[FORMData alloc] initWithJSON:JSON
                                  initialValues:@{@"companies[0].name" : @"Facebook",
                                                  @"companies[0].phone_number" : @"1222333",
                                                  @"companies[1].name" : @"Google"}
                               disabledFieldIDs:nil
                                       disabled:NO];
```

Should generate two dynamic sections with their fields pre-filled.

Before `companies[1].phone_number` was filled with `Google` when it should be filled with `nil`