### PR TITLE
Remove field values when resetting form

### DIFF
--- a/Source/FORMDataSource.h
+++ b/Source/FORMDataSource.h
@@ -36,7 +36,6 @@ typedef UICollectionViewCell * (^FORMFieldConfigureCellForItemAtIndexPath)(FORMF
 - (FORMField *)formFieldAtIndexPath:(NSIndexPath *)indexPath;
 
 - (void)resetForms;
-- (void)invalidateFields;
 - (void)validateForms;
 
 - (void)enable;

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -584,25 +584,16 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
     return YES;
 }
 
-- (void)invalidateFields
+- (void)resetForms
 {
-
     for (FORMGroup *form in self.formsManager.forms) {
         for (FORMField *field in form.fields) {
-
             field.value = nil;
-
         }
     }
 
     self.formsManager.values = nil;
 
-    [self.collectionView reloadData];
-}
-
-- (void)resetForms
-{
-    self.formsManager = nil;
     [self.collapsedForms removeAllObjects];
     [self.formsManager.hiddenFieldsAndFieldIDsDictionary removeAllObjects];
     [self.formsManager.hiddenSections removeAllObjects];


### PR DESCRIPTION
This is not the entire expected behavior, in my list is to improve this
method so it rollsback targets that have been run to their default
states

Also adding some tests for it