### PR TITLE
Refactor: rename forms to groups

### DIFF
--- a/Source/FORMData.h
+++ b/Source/FORMData.h
@@ -7,7 +7,7 @@ static NSString * const FORMHideTooltips = @"FORMHideTooltips";
 
 @interface FORMData : NSObject
 
-@property (nonatomic) NSMutableArray *forms;
+@property (nonatomic) NSMutableArray *groups;
 @property (nonatomic) NSMutableDictionary *hiddenFieldsAndFieldIDsDictionary;
 @property (nonatomic) NSMutableDictionary *hiddenSections;
 @property (nonatomic) NSArray *disabledFieldsIDs;
@@ -63,7 +63,7 @@ static NSString * const FORMHideTooltips = @"FORMHideTooltips";
 
 - (void)insertTemplateSectionWithID:(NSString *)sectionTemplateID
                  intoCollectionView:(UICollectionView *)collectionView
-                          usingForm:(FORMGroup *)form;
+                          usingGroup:(FORMGroup *)group;
 
 - (void)resetRemovedValues;
 

--- a/Source/FORMData.h
+++ b/Source/FORMData.h
@@ -63,7 +63,7 @@ static NSString * const FORMHideTooltips = @"FORMHideTooltips";
 
 - (void)insertTemplateSectionWithID:(NSString *)sectionTemplateID
                  intoCollectionView:(UICollectionView *)collectionView
-                          usingGroup:(FORMGroup *)group;
+                         usingGroup:(FORMGroup *)group;
 
 - (void)resetRemovedValues;
 

--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -50,13 +50,13 @@
 
 #pragma mark - Getters
 
-- (NSMutableArray *)forms
+- (NSMutableArray *)groups
 {
-    if (_forms) return _forms;
+    if (_groups) return _groups;
 
-    _forms = [NSMutableArray new];
+    _groups = [NSMutableArray new];
 
-    return _forms;
+    return _groups;
 }
 
 - (NSMutableDictionary *)hiddenFieldsAndFieldIDsDictionary
@@ -179,7 +179,7 @@
 
     [groups enumerateObjectsUsingBlock:^(NSDictionary *formDict, NSUInteger formIndex, BOOL *stop) {
 
-        FORMGroup *form = [[FORMGroup alloc] initWithDictionary:formDict
+        FORMGroup *group = [[FORMGroup alloc] initWithDictionary:formDict
                                                        position:formIndex
                                                        disabled:disabled
                                               disabledFieldsIDs:disabledFieldsIDs];
@@ -193,7 +193,7 @@
                         NSString *sectionID = [components firstObject];
 
                         FORMSection *existingSection;
-                        for (FORMSection *section in form.sections) {
+                        for (FORMSection *section in group.sections) {
                             if ([section.sectionID isEqualToString:sectionID]) {
                                 existingSection = section;
                             }
@@ -206,14 +206,14 @@
                         } else {
                             [self insertTemplateSectionWithID:sectionTemplateID
                                            intoCollectionView:nil
-                                                    usingForm:form];
+                                                    usingGroup:group];
                         }
                     }
                 }
             }
         }
 
-        for (FORMField *field in form.fields) {
+        for (FORMField *field in group.fields) {
 
             if ([initialValues andy_valueForKey:field.fieldID]) {
                 if (field.type == FORMFieldTypeSelect) {
@@ -277,7 +277,7 @@
             }
         }
 
-        [self.forms addObject:form];
+        [self.groups addObject:group];
     }];
 
     self.disabledFieldsIDs = disabledFields;
@@ -309,7 +309,7 @@
                 if (field) {
                     FORMSection *section = [self sectionWithID:field.section.sectionID];
                     [section removeField:field
-                                 inForms:self.forms];
+                                 inForms:self.groups];
                     [section resetFieldPositions];
                 }
 
@@ -317,8 +317,8 @@
 
                 FORMSection *section = [self sectionWithID:target.targetID];
                 if (section) {
-                    FORMGroup *form = section.form;
-                    [form removeSection:section];
+                    FORMGroup *group = section.group;
+                    [group removeSection:section];
                 }
             }
         }
@@ -329,8 +329,8 @@
 {
     NSMutableArray *invalidFormFields = [NSMutableArray new];
 
-    for (FORMGroup *form in self.forms) {
-        for (FORMSection *section in form.sections) {
+    for (FORMGroup *group in self.groups) {
+        for (FORMSection *section in group.sections) {
             for (FORMField *field in section.fields) {
                 BOOL fieldIsValid = (field.validation && [field validate] != FORMValidationResultTypePassed);
                 if (fieldIsValid) {
@@ -349,8 +349,8 @@
 
     _requiredFields = [NSMutableDictionary new];
 
-    for (FORMGroup *form in self.forms) {
-        for (FORMSection *section in form.sections) {
+    for (FORMGroup *group in self.groups) {
+        for (FORMSection *section in group.sections) {
             for (FORMField *field in section.fields) {
                 if (field.validation && field.validation.isRequired) {
                     [_requiredFields setObject:field forKey:field.fieldID];
@@ -413,8 +413,8 @@
 {
     FORMSection *foundSection = nil;
 
-    for (FORMGroup *form in self.forms) {
-        for (FORMSection *aSection in form.sections) {
+    for (FORMGroup *group in self.groups) {
+        for (FORMSection *aSection in group.sections) {
             if ([aSection.sectionID isEqualToString:sectionID]) {
                 foundSection = aSection;
                 break;
@@ -432,11 +432,11 @@
     NSMutableArray *indexPaths = [NSMutableArray new];
     NSUInteger formIndex = 0;
 
-    for (FORMGroup *form in self.forms) {
+    for (FORMGroup *group in self.groups) {
 
         NSInteger fieldsIndex = 0;
 
-        for (FORMSection *aSection in form.sections) {
+        for (FORMSection *aSection in group.sections) {
 
             for (__unused FORMField *aField in aSection.fields) {
                 if ([aSection.sectionID isEqualToString:sectionID]) {
@@ -464,10 +464,10 @@
     FORMField *foundField = nil;
 
     NSInteger formIndex = 0;
-    for (FORMGroup *form in self.forms) {
+    for (FORMGroup *group in self.groups) {
 
         NSUInteger fieldIndex = 0;
-        for (FORMField *field in form.fields) {
+        for (FORMField *field in group.fields) {
 
             if ([field.fieldID isEqualToString:fieldID]) {
                 foundField = field;
@@ -497,10 +497,10 @@ includingHiddenFields:(BOOL)includingHiddenFields
     __block NSIndexPath *indexPath = nil;
 
     NSInteger formIndex = 0;
-    for (FORMGroup *form in self.forms) {
+    for (FORMGroup *group in self.groups) {
 
         NSUInteger fieldIndex = 0;
-        for (FORMField *field in form.fields) {
+        for (FORMField *field in group.fields) {
 
             if ([field.fieldID isEqualToString:fieldID]) {
                 indexPath = [NSIndexPath indexPathForItem:fieldIndex
@@ -568,10 +568,10 @@ includingHiddenFields:(BOOL)includingHiddenFields
     }
 
     NSString *sectionID = removedSection.sectionID;
-    FORMGroup *form = removedSection.form;
+    FORMGroup *form = removedSection.group;
     [self sectionWithID:sectionID
              completion:^(FORMSection *foundSection, NSArray *indexPaths) {
-                 FORMGroup *foundForm = foundSection.form;
+                 FORMGroup *foundForm = foundSection.group;
                  [foundForm.sections removeObject:foundSection];
                  [collectionView deleteItemsAtIndexPaths:indexPaths];
              }];
@@ -668,12 +668,12 @@ includingHiddenFields:(BOOL)includingHiddenFields
             if (target.type == FORMTargetTypeField) {
                 FORMField *field = [self.hiddenFieldsAndFieldIDsDictionary objectForKey:target.targetID];
                 if (field) {
-                    FORMGroup *form = self.forms[[field.section.form.position integerValue]];
+                    FORMGroup *form = self.groups[[field.section.group.position integerValue]];
 
                     for (FORMSection *section in form.sections) {
                         if ([section.sectionID isEqualToString:field.section.sectionID]) {
                             foundSection = YES;
-                            NSInteger fieldIndex = [field indexInSectionUsingForms:self.forms];
+                            NSInteger fieldIndex = [field indexInSectionUsingForms:self.groups];
                             [section.fields insertObject:field atIndex:fieldIndex];
                             [section resetFieldPositions];
                         }
@@ -682,8 +682,8 @@ includingHiddenFields:(BOOL)includingHiddenFields
             } else if (target.type == FORMTargetTypeSection) {
                 FORMSection *section = [self.hiddenSections objectForKey:target.targetID];
                 if (section) {
-                    NSInteger sectionIndex = [section indexInForms:self.forms];
-                    FORMGroup *form = self.forms[[section.form.position integerValue]];
+                    NSInteger sectionIndex = [section indexInForms:self.groups];
+                    FORMGroup *form = self.groups[[section.group.position integerValue]];
                     [form.sections insertObject:section atIndex:sectionIndex];
                     [form resetSectionPositions];
                 }
@@ -773,7 +773,7 @@ includingHiddenFields:(BOOL)includingHiddenFields
     }
 
     for (FORMSection *section in deletedSections) {
-        FORMGroup *form = self.forms[[section.form.position integerValue]];
+        FORMGroup *form = self.groups[[section.group.position integerValue]];
 
         __block NSInteger index = 0;
         __block BOOL found = NO;
@@ -1014,8 +1014,8 @@ includingHiddenFields:(BOOL)includingHiddenFields
 {
     NSInteger numberOfFields = 0;
 
-    for (FORMGroup *form in self.forms) {
-        numberOfFields += [form numberOfFields];
+    for (FORMGroup *group in self.groups) {
+        numberOfFields += [group numberOfFields];
     }
 
     return numberOfFields;
@@ -1025,10 +1025,10 @@ includingHiddenFields:(BOOL)includingHiddenFields
 
 - (void)insertTemplateSectionWithID:(NSString *)sectionTemplateID
                  intoCollectionView:(UICollectionView *)collectionView
-                          usingForm:(FORMGroup *)form
+                          usingGroup:(FORMGroup *)group
 {
     FORMSection *foundSection;
-    for (FORMSection *aSection in form.sections) {
+    for (FORMSection *aSection in group.sections) {
         if ([aSection.sectionID isEqualToString:sectionTemplateID]) {
             foundSection = aSection;
             break;
@@ -1036,7 +1036,7 @@ includingHiddenFields:(BOOL)includingHiddenFields
     }
 
     if (foundSection) {
-        NSInteger index = [self indexForTemplateSectionWithID:sectionTemplateID inForm:form];
+        NSInteger index = [self indexForTemplateSectionWithID:sectionTemplateID inForm:group];
 
         NSDictionary *sectionTemplate = [self.sectionTemplatesDictionary valueForKey:sectionTemplateID];
         NSMutableDictionary *templateSectionDictionary = [NSMutableDictionary dictionaryWithDictionary:sectionTemplate];
@@ -1056,7 +1056,7 @@ includingHiddenFields:(BOOL)includingHiddenFields
 
         FORMSection *actionSection = [self sectionWithID:sectionTemplateID];
         NSInteger sectionPosition = [actionSection.position integerValue];
-        for (FORMSection *currentSection in form.sections) {
+        for (FORMSection *currentSection in group.sections) {
             if ([currentSection.sectionID hyp_containsString:sectionTemplateID]) {
                 if (!sectionPosition) {
                     sectionPosition = [currentSection.position integerValue];
@@ -1070,7 +1070,7 @@ includingHiddenFields:(BOOL)includingHiddenFields
                                                               disabled:self.disabledForm
                                                      disabledFieldsIDs:nil
                                                          isLastSection:YES];
-        section.form = form;
+        section.group = group;
 
         for (FORMField *field in section.fields) {
             field.value = [self.values andy_valueForKey:field.fieldID];
@@ -1082,9 +1082,9 @@ includingHiddenFields:(BOOL)includingHiddenFields
         }
 
         NSInteger sectionIndex = [section.position integerValue];
-        [form.sections insertObject:section atIndex:sectionIndex];
+        [group.sections insertObject:section atIndex:sectionIndex];
 
-        [form.sections enumerateObjectsUsingBlock:^(FORMSection *currentSection, NSUInteger idx, BOOL *stop) {
+        [group.sections enumerateObjectsUsingBlock:^(FORMSection *currentSection, NSUInteger idx, BOOL *stop) {
             if (idx > sectionIndex) {
                 currentSection.position = @([currentSection.position integerValue] + 1);
             }
@@ -1131,7 +1131,7 @@ includingHiddenFields:(BOOL)includingHiddenFields
 - (NSArray *)removedSectionsUsingInitialValues:(NSDictionary *)dictionary
 {
     NSMutableSet *currentSectionIDs = [NSMutableSet new];
-    for (FORMGroup *group in self.forms) {
+    for (FORMGroup *group in self.groups) {
         for (FORMSection *section in group.sections) {
             HYPParsedRelationship *parsed = [section.sectionID hyp_parseRelationship];
             if (parsed.toMany) {

--- a/Source/FORMDataSource.h
+++ b/Source/FORMDataSource.h
@@ -67,7 +67,7 @@ typedef UICollectionViewCell * (^FORMFieldConfigureCellForItemAtIndexPath)(FORMF
 - (FORMField *)fieldWithID:(NSString *)fieldID
      includingHiddenFields:(BOOL)includingHiddenFields;
 - (NSInteger)numberOfFields;
-- (NSArray *)forms;
+- (NSArray *)groups;
 - (NSDictionary *)values;
 - (NSDictionary *)removedValues;
 

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -559,13 +559,8 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
         }
     }
 
-<<<<<<< HEAD
-    for (FORMGroup *group in self.formsManager.groups) {
+    for (FORMGroup *group in self.formData.groups) {
         for (FORMField *field in group.fields) {
-=======
-    for (FORMGroup *form in self.formData.forms) {
-        for (FORMField *field in form.fields) {
->>>>>>> master
             if (![validatedFields containsObject:field.fieldID]) {
                 [field validate];
             }
@@ -575,13 +570,8 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
 
 - (BOOL)formFieldsAreValid
 {
-<<<<<<< HEAD
-    for (FORMGroup *group in self.formsManager.groups) {
+    for (FORMGroup *group in self.formData.groups) {
         for (FORMField *field in group.fields) {
-=======
-    for (FORMGroup *form in self.formData.forms) {
-        for (FORMField *field in form.fields) {
->>>>>>> master
             FORMValidationResultType fieldValidation = [field validate];
             BOOL requiredFieldFailedValidation = (fieldValidation != FORMValidationResultTypePassed);
             if (requiredFieldFailedValidation) {

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -70,9 +70,9 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
     layout.dataSource = self;
 
     _formData = [[FORMData alloc] initWithJSON:JSON
-                                     initialValues:values
-                                  disabledFieldIDs:@[]
-                                          disabled:disabled];
+                                 initialValues:values
+                              disabledFieldIDs:@[]
+                                      disabled:disabled];
 
     [collectionView registerClass:[FORMTextFieldCell class]
        forCellWithReuseIdentifier:FORMTextFieldCellIdentifier];
@@ -478,7 +478,7 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
     NSArray *removedSections = [self.formData removedSectionsUsingInitialValues:dictionary];
     for (FORMSection *section in removedSections) {
         [self.formData removeSection:section
-                        inCollectionView:self.collectionView];
+                    inCollectionView:self.collectionView];
     }
 
     [self.formData.values setValuesForKeysWithDictionary:dictionary];
@@ -490,23 +490,23 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
 
     [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
         [self.formData fieldWithID:key
-                 includingHiddenFields:YES
-                            completion:^(FORMField *field, NSIndexPath *indexPath) {
-                                BOOL shouldBeNil = ([value isEqual:[NSNull null]]);
+             includingHiddenFields:YES
+                        completion:^(FORMField *field, NSIndexPath *indexPath) {
+                            BOOL shouldBeNil = ([value isEqual:[NSNull null]]);
 
+                            if (field) {
+                                field.value = (shouldBeNil) ? nil : value;
+                                if (indexPath) {
+                                    [updatedIndexPaths addObject:indexPath];
+                                }
+                                [targets addObjectsFromArray:[field safeTargets]];
+                            } else {
+                                field = ([self fieldInDeletedFields:key]) ?: [self fieldInDeletedSections:key];
                                 if (field) {
                                     field.value = (shouldBeNil) ? nil : value;
-                                    if (indexPath) {
-                                        [updatedIndexPaths addObject:indexPath];
-                                    }
-                                    [targets addObjectsFromArray:[field safeTargets]];
-                                } else {
-                                    field = ([self fieldInDeletedFields:key]) ?: [self fieldInDeletedSections:key];
-                                    if (field) {
-                                        field.value = (shouldBeNil) ? nil : value;
-                                    }
                                 }
-                            }];
+                            }
+                        }];
     }];
 
     [self processTargets:targets];
@@ -614,15 +614,15 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
             NSString *sectionTemplateID = [components firstObject];
             FORMSection *section = [self sectionWithID:sectionTemplateID];
             [self.formData insertTemplateSectionWithID:sectionTemplateID
-                                        intoCollectionView:self.collectionView
-                                                 usingGroup:section.group];
+                                    intoCollectionView:self.collectionView
+                                            usingGroup:section.group];
         } else if ([components.lastObject isEqualToString:FORMDynamicRemoveFieldID]) {
             HYPParsedRelationship *parsed = [field.fieldID hyp_parseRelationship];
             parsed.attribute = nil;
             NSString *sectionID = [parsed key];
             FORMSection *section = [self.formData sectionWithID:sectionID];
             [self.formData removeSection:section
-                            inCollectionView:self.collectionView];
+                        inCollectionView:self.collectionView];
         }
     }
 
@@ -862,7 +862,7 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
            completion:(void (^)(FORMSection *section, NSArray *indexPaths))completion
 {
     [self.formData sectionWithID:sectionID
-                          completion:completion];
+                      completion:completion];
 }
 
 - (void)indexForFieldWithID:(NSString *)fieldID
@@ -870,14 +870,14 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
                  completion:(void (^)(FORMSection *section, NSInteger index))completion
 {
     [self.formData indexForFieldWithID:fieldID
-                           inSectionWithID:sectionID completion:completion];
+                       inSectionWithID:sectionID completion:completion];
 }
 
 - (FORMField *)fieldWithID:(NSString *)fieldID
      includingHiddenFields:(BOOL)includingHiddenFields
 {
     return [self.formData fieldWithID:fieldID
-                    includingHiddenFields:includingHiddenFields];
+                includingHiddenFields:includingHiddenFields];
 }
 
 - (void)fieldWithID:(NSString *)fieldID
@@ -885,8 +885,8 @@ includingHiddenFields:(BOOL)includingHiddenFields
          completion:(void (^)(FORMField *field, NSIndexPath *indexPath))completion
 {
     [self.formData fieldWithID:fieldID
-             includingHiddenFields:includingHiddenFields
-                        completion:completion];
+         includingHiddenFields:includingHiddenFields
+                    completion:completion];
 }
 
 - (NSArray *)showTargets:(NSArray *)targets
@@ -982,8 +982,8 @@ includingHiddenFields:(BOOL)includingHiddenFields
             FORMSection *section = [self sectionWithID:key];
             for (NSInteger numberOfSections = 0; numberOfSections < [obj count]; numberOfSections++) {
                 [self.formData insertTemplateSectionWithID:key
-                                            intoCollectionView:self.collectionView
-                                                     usingGroup:section.group];
+                                        intoCollectionView:self.collectionView
+                                                usingGroup:section.group];
             }
         }
     }];

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -191,13 +191,13 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
                                                                              withReuseIdentifier:FORMHeaderReuseIdentifier
                                                                                     forIndexPath:indexPath];
 
-        FORMGroup *form = self.formData.groups[indexPath.section];
+        FORMGroup *group = self.formData.groups[indexPath.section];
         headerView.section = indexPath.section;
 
         if (self.configureHeaderViewBlock) {
-            self.configureHeaderViewBlock(headerView, kind, indexPath, form);
+            self.configureHeaderViewBlock(headerView, kind, indexPath, group);
         } else {
-            headerView.headerLabel.text = form.title;
+            headerView.headerLabel.text = group.title;
             headerView.delegate = self;
         }
 
@@ -767,12 +767,12 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
 {
     NSMutableArray *indexPaths = [NSMutableArray new];
 
-    NSInteger formIndex = [section.group.position integerValue];
-    FORMGroup *form = self.formData.groups[formIndex];
+    NSInteger groupIndex = [section.group.position integerValue];
+    FORMGroup *group = self.formData.groups[groupIndex];
 
     NSInteger fieldsIndex = 0;
     NSInteger sectionIndex = 0;
-    for (FORMSection *aSection in form.sections) {
+    for (FORMSection *aSection in group.sections) {
         if ([aSection.position integerValue] < [section.position integerValue]) {
             fieldsIndex += aSection.fields.count;
             sectionIndex++;
@@ -781,7 +781,7 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
 
     NSInteger fieldsInSectionCount = fieldsIndex + section.fields.count;
     for (NSInteger i = fieldsIndex; i < fieldsInSectionCount; i++) {
-        [indexPaths addObject:[NSIndexPath indexPathForRow:i inSection:formIndex]];
+        [indexPaths addObject:[NSIndexPath indexPathForRow:i inSection:groupIndex]];
     }
 
     if (completion) {
@@ -823,7 +823,7 @@ static NSString * const FORMDynamicRemoveFieldID = @"remove";
 
 #pragma mark - FORMHeaderViewDelegate
 
-- (void)formHeaderViewWasPressed:(FORMGroupHeaderView *)headerView
+- (void)groupHeaderViewWasPressed:(FORMGroupHeaderView *)headerView
 {
     [self collapseFieldsInSection:headerView.section
                    collectionView:self.collectionView];

--- a/Source/FORMGroupHeaderView.h
+++ b/Source/FORMGroupHeaderView.h
@@ -23,6 +23,6 @@ static NSString * const FORMHeaderReuseIdentifier = @"FORMHeaderReuseIdentifier"
 
 @protocol FORMHeaderViewDelegate <NSObject>
 
-- (void)formHeaderViewWasPressed:(FORMGroupHeaderView *)headerView;
+- (void)groupHeaderViewWasPressed:(FORMGroupHeaderView *)headerView;
 
 @end

--- a/Source/FORMGroupHeaderView.m
+++ b/Source/FORMGroupHeaderView.m
@@ -55,8 +55,8 @@
 
 - (void)headerTappedAction
 {
-    if ([self.delegate respondsToSelector:@selector(formHeaderViewWasPressed:)]) {
-        [self.delegate formHeaderViewWasPressed:self];
+    if ([self.delegate respondsToSelector:@selector(groupHeaderViewWasPressed:)]) {
+        [self.delegate groupHeaderViewWasPressed:self];
     }
 }
 

--- a/Source/FORMLayout.h
+++ b/Source/FORMLayout.h
@@ -14,7 +14,7 @@ static const NSInteger FORMMarginBottom = 30.0f;
 
 @protocol FORMLayoutDataSource <NSObject>
 
-- (NSArray *)forms;
-- (NSArray *)collapsedForms;
+- (NSArray *)groups;
+- (NSArray *)collapsedGroups;
 
 @end

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -168,10 +168,10 @@
 
 - (NSMutableArray *)fieldsAtSection:(NSInteger)section
 {
-    NSArray *forms = nil;
+    NSArray *groups = nil;
 
     if ([self.dataSource respondsToSelector:@selector(groups)]) {
-        forms = [self.dataSource groups];
+        groups = [self.dataSource groups];
     } else {
         abort();
     }
@@ -184,13 +184,13 @@
         abort();
     }
 
-    FORMGroup *form = forms[section];
+    FORMGroup *group = groups[section];
     NSMutableArray *fields = nil;
 
     if ([collapsedGroups containsObject:@(section)]) {
         fields = [NSMutableArray new];
     } else {
-        fields = [NSMutableArray arrayWithArray:form.fields];
+        fields = [NSMutableArray arrayWithArray:group.fields];
     }
 
     return fields;

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -170,16 +170,16 @@
 {
     NSArray *forms = nil;
 
-    if ([self.dataSource respondsToSelector:@selector(forms)]) {
-        forms = [self.dataSource forms];
+    if ([self.dataSource respondsToSelector:@selector(groups)]) {
+        forms = [self.dataSource groups];
     } else {
         abort();
     }
 
-    NSArray *collapsedForms = nil;
+    NSArray *collapsedGroups = nil;
 
-    if ([self.dataSource respondsToSelector:@selector(collapsedForms)]) {
-        collapsedForms = [self.dataSource collapsedForms];
+    if ([self.dataSource respondsToSelector:@selector(collapsedGroups)]) {
+        collapsedGroups = [self.dataSource collapsedGroups];
     } else {
         abort();
     }
@@ -187,7 +187,7 @@
     FORMGroup *form = forms[section];
     NSMutableArray *fields = nil;
 
-    if ([collapsedForms containsObject:@(section)]) {
+    if ([collapsedGroups containsObject:@(section)]) {
         fields = [NSMutableArray new];
     } else {
         fields = [NSMutableArray arrayWithArray:form.fields];

--- a/Source/Models/FORMField.h
+++ b/Source/Models/FORMField.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, FORMFieldType) {
 
 - (FORMFieldValue *)selectFieldValueWithValueID:(id)fieldValueID;
 
-- (NSUInteger)indexInSectionUsingForms:(NSArray *)forms;
+- (NSUInteger)indexInSectionUsingGroups:(NSArray *)groups;
 
 - (NSArray *)safeTargets;
 

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -287,7 +287,7 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
 
 - (NSUInteger)indexInSectionUsingForms:(NSArray *)forms
 {
-    FORMGroup *form = forms[[self.section.form.position integerValue]];
+    FORMGroup *form = forms[[self.section.group.position integerValue]];
     FORMSection *section = form.sections[[self.section.position integerValue]];
 
     NSUInteger index = 0;

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -259,8 +259,8 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
 
     if (self.validation.compareToFieldID.length) {
         FORMField *field = [self.class fieldForFieldID:self.validation.compareToFieldID inSection:self.section];
-      id dependantFieldValue = field.value;
-      self.validationType = [validator validateFieldValue:self.value withDependentValue:dependantFieldValue withComparator:self.validation.compareRule];
+        id dependantFieldValue = field.value;
+        self.validationType = [validator validateFieldValue:self.value withDependentValue:dependantFieldValue withComparator:self.validation.compareRule];
     }
     self.valid = (self.validationType == FORMValidationResultTypePassed);
     return self.validationType;
@@ -276,13 +276,13 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
 
 + (FORMField *)fieldForFieldID:(NSString *)fieldID inSection:(FORMSection *)section
 {
-  __block FORMField *formField;
-  [section.fields enumerateObjectsUsingBlock:^(FORMField *field, NSUInteger idx, BOOL *stop) {
-    if ([field.fieldID isEqualToString:fieldID]) {
-      formField = field;
-    }
-  }];
-  return formField;
+    __block FORMField *formField;
+    [section.fields enumerateObjectsUsingBlock:^(FORMField *field, NSUInteger idx, BOOL *stop) {
+        if ([field.fieldID isEqualToString:fieldID]) {
+            formField = field;
+        }
+    }];
+    return formField;
 }
 
 - (NSUInteger)indexInSectionUsingGroups:(NSArray *)groups

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -285,10 +285,10 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
   return formField;
 }
 
-- (NSUInteger)indexInSectionUsingForms:(NSArray *)forms
+- (NSUInteger)indexInSectionUsingGroups:(NSArray *)groups
 {
-    FORMGroup *form = forms[[self.section.group.position integerValue]];
-    FORMSection *section = form.sections[[self.section.position integerValue]];
+    FORMGroup *group = groups[[self.section.group.position integerValue]];
+    FORMSection *section = group.sections[[self.section.position integerValue]];
 
     NSUInteger index = 0;
     BOOL found = NO;

--- a/Source/Models/FORMGroup.m
+++ b/Source/Models/FORMGroup.m
@@ -45,7 +45,7 @@
                                                            disabledFieldsIDs:disabledFieldsIDs
                                                                isLastSection:isLastSection];
 
-        section.form = self;
+        section.group = self;
 
         [sections addObject:section];
     }];

--- a/Source/Models/FORMGroup.m
+++ b/Source/Models/FORMGroup.m
@@ -40,10 +40,10 @@
         BOOL isLastSection = (lastObject == sectionDict);
 
         FORMSection *section = [[FORMSection alloc] initWithDictionary:sectionDict
-                                                                    position:sectionIndex
-                                                                    disabled:disabled
-                                                           disabledFieldsIDs:disabledFieldsIDs
-                                                               isLastSection:isLastSection];
+                                                              position:sectionIndex
+                                                              disabled:disabled
+                                                     disabledFieldsIDs:disabledFieldsIDs
+                                                         isLastSection:isLastSection];
 
         section.group = self;
 

--- a/Source/Models/FORMSection.h
+++ b/Source/Models/FORMSection.h
@@ -29,13 +29,13 @@ typedef NS_ENUM(NSInteger, FORMSectionType) {
                      isLastSection:(BOOL)isLastSection NS_DESIGNATED_INITIALIZER;
 
 + (void)sectionAndIndexForField:(FORMField *)field
-                        inForms:(NSArray *)forms
+                       inGroups:(NSArray *)groups
                      completion:(void (^)(BOOL found,
                                           FORMSection *section,
                                           NSInteger index))completion;
 
-- (NSInteger)indexInForms:(NSArray *)forms;
-- (void)removeField:(FORMField *)field inForms:(NSArray *)forms;
+- (NSInteger)indexInGroups:(NSArray *)groups;
+- (void)removeField:(FORMField *)field inGroups:(NSArray *)groups;
 - (void)resetFieldPositions;
 
 @end

--- a/Source/Models/FORMSection.h
+++ b/Source/Models/FORMSection.h
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSInteger, FORMSectionType) {
 @property (nonatomic) NSMutableArray *fields;
 @property (nonatomic) NSString *sectionID;
 @property (nonatomic) NSNumber *position;
-@property (nonatomic) FORMGroup *form;
+@property (nonatomic) FORMGroup *group;
 @property (nonatomic) NSString *typeString;
 @property (nonatomic) FORMSectionType type;
 

--- a/Source/Models/FORMSection.m
+++ b/Source/Models/FORMSection.m
@@ -87,7 +87,7 @@
                                           FORMSection *section,
                                           NSInteger index))completion
 {
-    FORMGroup *form = forms[[field.section.form.position integerValue]];
+    FORMGroup *form = forms[[field.section.group.position integerValue]];
     FORMSection *section = form.sections[[field.section.position integerValue]];
 
     __block NSInteger index = 0;
@@ -109,7 +109,7 @@
 
 - (NSInteger)indexInForms:(NSArray *)forms
 {
-    FORMGroup *form = forms[[self.form.position integerValue]];
+    FORMGroup *form = forms[[self.group.position integerValue]];
 
     BOOL found = NO;
     NSInteger index = 0;
@@ -164,7 +164,7 @@
     }
 
     return [NSString stringWithFormat:@"\n — Section: %@ —\n position: %@\n formID: %@\n shouldValidate: %@\n containsSpecialField: %@\n isLast: %@\n fields: %@\n",
-            self.sectionID, self.position, self.form.formID, self.shouldValidate ? @"YES" : @"NO", self.containsSpecialField ? @"YES" : @"NO", self.isLast ? @"YES" : @"NO", fields];
+            self.sectionID, self.position, self.group.formID, self.shouldValidate ? @"YES" : @"NO", self.containsSpecialField ? @"YES" : @"NO", self.isLast ? @"YES" : @"NO", fields];
 }
 
 @end

--- a/Source/Models/FORMSection.m
+++ b/Source/Models/FORMSection.m
@@ -82,13 +82,13 @@
 #pragma mark Class
 
 + (void)sectionAndIndexForField:(FORMField *)field
-                        inForms:(NSArray *)forms
+                       inGroups:(NSArray *)groups
                      completion:(void (^)(BOOL found,
                                           FORMSection *section,
                                           NSInteger index))completion
 {
-    FORMGroup *form = forms[[field.section.group.position integerValue]];
-    FORMSection *section = form.sections[[field.section.position integerValue]];
+    FORMGroup *group = groups[[field.section.group.position integerValue]];
+    FORMSection *section = group.sections[[field.section.position integerValue]];
 
     __block NSInteger index = 0;
     __block BOOL found = NO;
@@ -107,15 +107,15 @@
 
 #pragma mark Instance
 
-- (NSInteger)indexInForms:(NSArray *)forms
+- (NSInteger)indexInGroups:(NSArray *)groups
 {
-    FORMGroup *form = forms[[self.group.position integerValue]];
+    FORMGroup *group = groups[[self.group.position integerValue]];
 
     BOOL found = NO;
     NSInteger index = 0;
     NSUInteger idx = 0;
 
-    for (FORMSection *aSection in form.sections) {
+    for (FORMSection *aSection in group.sections) {
         if ([aSection.position integerValue] >= [self.position integerValue]) {
             index = idx;
             found = YES;
@@ -125,12 +125,12 @@
         idx++;
     }
 
-    if (!found) index = [form.sections count];
+    if (!found) index = [group.sections count];
 
     return index;
 }
 
-- (void)removeField:(FORMField *)field inForms:(NSArray *)forms
+- (void)removeField:(FORMField *)field inGroups:(NSArray *)groups
 {
     __block NSInteger index = 0;
     __block BOOL found = NO;

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -39,13 +39,13 @@
     [dataSource processTarget:[FORMTarget hideFieldTargetWithID:@"display_name"]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"display_name"]];
     FORMField *field = [dataSource fieldWithID:@"display_name" includingHiddenFields:YES];
-    NSUInteger index = [field indexInSectionUsingForms:dataSource.forms];
+    NSUInteger index = [field indexInSectionUsingForms:dataSource.groups];
     XCTAssertEqual(index, 2);
 
     [dataSource processTarget:[FORMTarget hideFieldTargetWithID:@"username"]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"username"]];
     field = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:dataSource.forms];
+    index = [field indexInSectionUsingForms:dataSource.groups];
     XCTAssertEqual(index, 2);
 
     [dataSource processTargets:[FORMTarget hideFieldTargetsWithIDs:@[@"first_name",
@@ -53,7 +53,7 @@
                                                                      @"username"]]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"username"]];
     field = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:dataSource.forms];
+    index = [field indexInSectionUsingForms:dataSource.groups];
     XCTAssertEqual(index, 1);
     [dataSource processTargets:[FORMTarget showFieldTargetsWithIDs:@[@"first_name",
                                                                      @"address"]]];
@@ -62,7 +62,7 @@
                                                                      @"address"]]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"address"]];
     field = [dataSource fieldWithID:@"address" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:dataSource.forms];
+    index = [field indexInSectionUsingForms:dataSource.groups];
     XCTAssertEqual(index, 0);
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"last_name"]];
 }
@@ -213,7 +213,7 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.forms[0];
+    FORMGroup *form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 5);
     FORMSection *section = form.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
@@ -223,7 +223,7 @@
     FORMField *removeField = [dataSource fieldWithID:@"companies[0].remove" includingHiddenFields:YES];
     [dataSource fieldCell:nil updatedWithField:removeField];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 4);
     section = form.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"personal-details-0");
@@ -234,7 +234,7 @@
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 5);
     section = form.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
@@ -256,7 +256,7 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.forms[0];
+    FORMGroup *form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 5);
 
     FORMField *field = [dataSource fieldWithID:@"companies.add" includingHiddenFields:NO];
@@ -264,12 +264,12 @@
     [dataSource fieldCell:nil updatedWithField:field];
     [dataSource fieldCell:nil updatedWithField:field];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 7);
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 5);
     FORMSection *section = form.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
@@ -293,7 +293,7 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.forms[0];
+    FORMGroup *form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 6);
 
     FORMField *removeField = [dataSource fieldWithID:@"companies[0].remove" includingHiddenFields:YES];
@@ -301,12 +301,12 @@
     [dataSource fieldCell:nil updatedWithField:removeField];
     [dataSource fieldCell:nil updatedWithField:removeField];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 4);
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 6);
     FORMSection *section = form.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
@@ -330,7 +330,7 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.forms[0];
+    FORMGroup *form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 8);
     FORMSection *section = form.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
@@ -339,12 +339,12 @@
     XCTAssertNotNil(removeField);
     [dataSource fieldCell:nil updatedWithField:removeField];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 7);
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 8);
     section = form.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
@@ -368,7 +368,7 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.forms[0];
+    FORMGroup *form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 8);
     FORMSection *section = form.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
@@ -383,7 +383,7 @@
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 8);
 }
 
@@ -411,7 +411,7 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.forms[0];
+    FORMGroup *form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 8);
     FORMSection *section = form.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
@@ -426,7 +426,7 @@
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.forms[0];
+    form = dataSource.groups[0];
     XCTAssertEqual(form.sections.count, 8);
 }
 

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -39,13 +39,13 @@
     [dataSource processTarget:[FORMTarget hideFieldTargetWithID:@"display_name"]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"display_name"]];
     FORMField *field = [dataSource fieldWithID:@"display_name" includingHiddenFields:YES];
-    NSUInteger index = [field indexInSectionUsingForms:dataSource.groups];
+    NSUInteger index = [field indexInSectionUsingGroups:dataSource.groups];
     XCTAssertEqual(index, 2);
 
     [dataSource processTarget:[FORMTarget hideFieldTargetWithID:@"username"]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"username"]];
     field = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:dataSource.groups];
+    index = [field indexInSectionUsingGroups:dataSource.groups];
     XCTAssertEqual(index, 2);
 
     [dataSource processTargets:[FORMTarget hideFieldTargetsWithIDs:@[@"first_name",
@@ -53,7 +53,7 @@
                                                                      @"username"]]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"username"]];
     field = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:dataSource.groups];
+    index = [field indexInSectionUsingGroups:dataSource.groups];
     XCTAssertEqual(index, 1);
     [dataSource processTargets:[FORMTarget showFieldTargetsWithIDs:@[@"first_name",
                                                                      @"address"]]];
@@ -62,7 +62,7 @@
                                                                      @"address"]]];
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"address"]];
     field = [dataSource fieldWithID:@"address" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:dataSource.groups];
+    index = [field indexInSectionUsingGroups:dataSource.groups];
     XCTAssertEqual(index, 0);
     [dataSource processTarget:[FORMTarget showFieldTargetWithID:@"last_name"]];
 }
@@ -213,9 +213,9 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 5);
-    FORMSection *section = form.sections[1];
+    FORMGroup *group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 5);
+    FORMSection *section = group.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
     XCTAssertEqualObjects(dataSource.values, initialValues);
     XCTAssertEqual(dataSource.removedValues.count, 0);
@@ -223,9 +223,9 @@
     FORMField *removeField = [dataSource fieldWithID:@"companies[0].remove" includingHiddenFields:YES];
     [dataSource fieldCell:nil updatedWithField:removeField];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 4);
-    section = form.sections[1];
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 4);
+    section = group.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"personal-details-0");
     XCTAssertNil([dataSource.values valueForKey:@"companies[0].name"]);
     XCTAssertNil([dataSource.values valueForKey:@"companies[0].phone_number"]);
@@ -234,9 +234,9 @@
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 5);
-    section = form.sections[1];
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 5);
+    section = group.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
     XCTAssertEqualObjects(dataSource.values, initialValues);
 }
@@ -256,22 +256,22 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 5);
+    FORMGroup *group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 5);
 
     FORMField *field = [dataSource fieldWithID:@"companies.add" includingHiddenFields:NO];
     XCTAssertNotNil(field);
     [dataSource fieldCell:nil updatedWithField:field];
     [dataSource fieldCell:nil updatedWithField:field];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 7);
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 7);
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 5);
-    FORMSection *section = form.sections[1];
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 5);
+    FORMSection *section = group.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
     XCTAssertEqualObjects(dataSource.values, initialValues);
 }
@@ -293,22 +293,22 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 6);
+    FORMGroup *group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 6);
 
     FORMField *removeField = [dataSource fieldWithID:@"companies[0].remove" includingHiddenFields:YES];
     XCTAssertNotNil(removeField);
     [dataSource fieldCell:nil updatedWithField:removeField];
     [dataSource fieldCell:nil updatedWithField:removeField];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 4);
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 4);
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 6);
-    FORMSection *section = form.sections[1];
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 6);
+    FORMSection *section = group.sections[1];
     XCTAssertEqualObjects(section.sectionID, @"companies[0]");
     XCTAssertEqualObjects(dataSource.values, initialValues);
 }
@@ -330,23 +330,23 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
-    FORMSection *section = form.sections[2];
+    FORMGroup *group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
+    FORMSection *section = group.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     FORMField *removeField = [dataSource fieldWithID:@"companies[1].remove" includingHiddenFields:YES];
     XCTAssertNotNil(removeField);
     [dataSource fieldCell:nil updatedWithField:removeField];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 7);
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 7);
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
-    section = form.sections[2];
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
+    section = group.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     XCTAssertEqualObjects([dataSource.values hyp_dictionaryByRemovingNullItems], initialValues);
@@ -368,9 +368,9 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
-    FORMSection *section = form.sections[2];
+    FORMGroup *group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
+    FORMSection *section = group.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     FORMField *removeField = [dataSource fieldWithID:@"companies[1].remove" includingHiddenFields:YES];
@@ -383,8 +383,8 @@
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
 }
 
 - (void)testResetDynamicSectionsWithDictionaryF
@@ -411,9 +411,9 @@
                                                                values:initialValues
                                                              disabled:NO];
 
-    FORMGroup *form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
-    FORMSection *section = form.sections[2];
+    FORMGroup *group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
+    FORMSection *section = group.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     FORMField *removeField = [dataSource fieldWithID:@"companies[1].remove" includingHiddenFields:YES];
@@ -426,8 +426,8 @@
 
     [dataSource resetDynamicSectionsWithDictionary:initialValues];
 
-    form = dataSource.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
+    group = dataSource.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
 }
 
 #pragma mark - processTarget

--- a/Tests/Tests/FORMDataTests.m
+++ b/Tests/Tests/FORMDataTests.m
@@ -215,7 +215,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfFields = [[[normalformData.groups firstObject] fields] count];
+    NSUInteger numberOfFields = [[[normalFormData.groups firstObject] fields] count];
     XCTAssertEqual(numberOfFields, 2);
 
     FORMData *evaluatedFormData = [[FORMData alloc] initWithJSON:JSON
@@ -224,7 +224,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfFieldsWithHiddenTargets = [[[evaluatedformData.groups firstObject] fields] count];
+    NSUInteger numberOfFieldsWithHiddenTargets = [[[evaluatedFormData.groups firstObject] fields] count];
     XCTAssertEqual(numberOfFieldsWithHiddenTargets, 3);
 }
 
@@ -262,7 +262,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfSections = [[[normalformData.groups firstObject] sections] count];
+    NSUInteger numberOfSections = [[[normalFormData.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSections, 2);
 
     FORMData *evaluatedFormData = [[FORMData alloc] initWithJSON:JSON
@@ -271,7 +271,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedformData.groups firstObject] sections] count];
+    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedFormData.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSectionsWithHiddenTargets, 3);
 }
 
@@ -285,7 +285,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfSections = [[[normalformData.groups firstObject] sections] count];
+    NSUInteger numberOfSections = [[[normalFormData.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSections, 3);
 
     FORMData *evaluatedFormData = [[FORMData alloc] initWithJSON:JSON
@@ -294,7 +294,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedformData.groups firstObject] sections] count];
+    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedFormData.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSectionsWithHiddenTargets, 2);
 }
 

--- a/Tests/Tests/FORMDataTests.m
+++ b/Tests/Tests/FORMDataTests.m
@@ -28,9 +28,9 @@
                                       disabledFieldIDs:nil
                                               disabled:NO];
 
-    XCTAssertNotNil(manager.forms);
+    XCTAssertNotNil(manager.groups);
 
-    XCTAssertTrue(manager.forms.count > 0);
+    XCTAssertTrue(manager.groups.count > 0);
 
     XCTAssertTrue(manager.hiddenFieldsAndFieldIDsDictionary.count == 0);
 
@@ -215,7 +215,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfFields = [[[normalManager.forms firstObject] fields] count];
+    NSUInteger numberOfFields = [[[normalManager.groups firstObject] fields] count];
     XCTAssertEqual(numberOfFields, 2);
 
     FORMData *evaluatedManager = [[FORMData alloc] initWithJSON:JSON
@@ -224,7 +224,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfFieldsWithHiddenTargets = [[[evaluatedManager.forms firstObject] fields] count];
+    NSUInteger numberOfFieldsWithHiddenTargets = [[[evaluatedManager.groups firstObject] fields] count];
     XCTAssertEqual(numberOfFieldsWithHiddenTargets, 3);
 }
 
@@ -238,7 +238,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfFields = [[[normalManager.forms firstObject] fields] count];
+    NSUInteger numberOfFields = [[[normalManager.groups firstObject] fields] count];
     XCTAssertEqual(numberOfFields, 3);
 
     FORMData *evaluatedManager = [[FORMData alloc] initWithJSON:JSON
@@ -247,7 +247,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfFieldsWithHiddenTargets = [[[evaluatedManager.forms firstObject] fields] count];
+    NSUInteger numberOfFieldsWithHiddenTargets = [[[evaluatedManager.groups firstObject] fields] count];
     XCTAssertEqual(numberOfFieldsWithHiddenTargets, 2);
 }
 
@@ -262,7 +262,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfSections = [[[normalManager.forms firstObject] sections] count];
+    NSUInteger numberOfSections = [[[normalManager.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSections, 2);
 
     FORMData *evaluatedManager = [[FORMData alloc] initWithJSON:JSON
@@ -271,7 +271,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedManager.forms firstObject] sections] count];
+    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedManager.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSectionsWithHiddenTargets, 3);
 }
 
@@ -285,7 +285,7 @@
                                             disabledFieldIDs:nil
                                                     disabled:NO];
 
-    NSUInteger numberOfSections = [[[normalManager.forms firstObject] sections] count];
+    NSUInteger numberOfSections = [[[normalManager.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSections, 3);
 
     FORMData *evaluatedManager = [[FORMData alloc] initWithJSON:JSON
@@ -294,7 +294,7 @@
                                                disabledFieldIDs:nil
                                                        disabled:NO];
 
-    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedManager.forms firstObject] sections] count];
+    NSUInteger numberOfSectionsWithHiddenTargets = [[[evaluatedManager.groups firstObject] sections] count];
     XCTAssertEqual(numberOfSectionsWithHiddenTargets, 2);
 }
 
@@ -415,7 +415,7 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *group = formData.forms[0];
+    FORMGroup *group = formData.groups[0];
     XCTAssertEqual(group.sections.count, 6);
     NSArray *sectionPositions = @[@0, @1, @2, @3, @4, @5];
     NSArray *comparedSectionPositions = [group.sections valueForKey:@"position"];
@@ -452,7 +452,7 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *group = formData.forms[0];
+    FORMGroup *group = formData.groups[0];
     XCTAssertEqual(group.sections.count, 5);
     NSArray *sectionPositions = @[@0, @1, @2, @3, @4];
     NSArray *comparedSectionPositions = [group.sections valueForKey:@"position"];
@@ -484,7 +484,7 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *group = formData.forms[0];
+    FORMGroup *group = formData.groups[0];
     XCTAssertEqual(group.sections.count, 6);
     NSArray *sectionPositions = @[@0, @1, @2, @3, @4, @5];
     NSArray *comparedSectionPositions = [group.sections valueForKey:@"position"];
@@ -524,7 +524,7 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *form = formData.forms[0];
+    FORMGroup *form = formData.groups[0];
     XCTAssertEqual(form.sections.count, 5);
 
     NSDictionary *sectionDictionary = @{@"id" : @"companies[1]",
@@ -565,14 +565,14 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *form = formData.forms[0];
+    FORMGroup *form = formData.groups[0];
     XCTAssertEqual(form.sections.count, 8);
     FORMSection *section = form.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     [formData removeSection:section inCollectionView:nil];
 
-    form = formData.forms[0];
+    form = formData.groups[0];
     XCTAssertEqual(form.sections.count, 7);
 
     NSArray *removedSections = [formData removedSectionsUsingInitialValues:initialValues];
@@ -595,7 +595,7 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *form = formData.forms[0];
+    FORMGroup *form = formData.groups[0];
     XCTAssertEqual(form.sections.count, 8);
     FORMSection *section = form.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
@@ -619,7 +619,7 @@
                                         isLastSection:NO];
     [form.sections insertObject:section atIndex:2];
 
-    form = formData.forms[0];
+    form = formData.groups[0];
     XCTAssertEqual(form.sections.count, 8);
 
     NSArray *removedSections = [formData removedSectionsUsingInitialValues:initialValues];

--- a/Tests/Tests/FORMDataTests.m
+++ b/Tests/Tests/FORMDataTests.m
@@ -524,8 +524,8 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *form = formData.groups[0];
-    XCTAssertEqual(form.sections.count, 5);
+    FORMGroup *group = formData.groups[0];
+    XCTAssertEqual(group.sections.count, 5);
 
     NSDictionary *sectionDictionary = @{@"id" : @"companies[1]",
                                         @"fields":@[
@@ -542,7 +542,7 @@
                                                           disabled:NO
                                                  disabledFieldsIDs:nil
                                                      isLastSection:NO];
-    [form.sections insertObject:section atIndex:2];
+    [group.sections insertObject:section atIndex:2];
 
     NSArray *removedSections = [formData removedSectionsUsingInitialValues:initialValues];
     NSArray *sectionIDs = [removedSections valueForKey:@"sectionID"];
@@ -565,15 +565,15 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *form = formData.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
-    FORMSection *section = form.sections[2];
+    FORMGroup *group = formData.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
+    FORMSection *section = group.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     [formData removeSection:section inCollectionView:nil];
 
-    form = formData.groups[0];
-    XCTAssertEqual(form.sections.count, 7);
+    group = formData.groups[0];
+    XCTAssertEqual(group.sections.count, 7);
 
     NSArray *removedSections = [formData removedSectionsUsingInitialValues:initialValues];
     NSArray *sectionIDs = [removedSections valueForKey:@"sectionID"];
@@ -595,9 +595,9 @@
                                        disabledFieldIDs:nil
                                                disabled:NO];
 
-    FORMGroup *form = formData.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
-    FORMSection *section = form.sections[2];
+    FORMGroup *group = formData.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
+    FORMSection *section = group.sections[2];
     XCTAssertEqualObjects(section.sectionID, @"companies[1]");
 
     [formData removeSection:section inCollectionView:nil];
@@ -617,10 +617,10 @@
                                              disabled:NO
                                     disabledFieldsIDs:nil
                                         isLastSection:NO];
-    [form.sections insertObject:section atIndex:2];
+    [group.sections insertObject:section atIndex:2];
 
-    form = formData.groups[0];
-    XCTAssertEqual(form.sections.count, 8);
+    group = formData.groups[0];
+    XCTAssertEqual(group.sections.count, 8);
 
     NSArray *removedSections = [formData removedSectionsUsingInitialValues:initialValues];
     NSArray *sectionIDs = [removedSections valueForKey:@"sectionID"];

--- a/Tests/Tests/FORMTests.m
+++ b/Tests/Tests/FORMTests.m
@@ -10,27 +10,27 @@
 
 - (void)testInitWithDictionary
 {
-    FORMGroup *form = [[FORMGroup alloc] initWithDictionary:@{@"id": @"some_form",
+    FORMGroup *group = [[FORMGroup alloc] initWithDictionary:@{@"id": @"some_form",
                                                               @"title": @"Some form"}
                                                    position:0
                                                    disabled:NO
                                           disabledFieldsIDs:nil];
 
-    XCTAssertNotNil(form);
-    XCTAssertEqualObjects(form.formID, @"some_form");
-    XCTAssertEqualObjects(form.title, @"Some form");
-    XCTAssertEqualObjects(form.position, @0);
+    XCTAssertNotNil(group);
+    XCTAssertEqualObjects(group.formID, @"some_form");
+    XCTAssertEqualObjects(group.title, @"Some form");
+    XCTAssertEqualObjects(group.position, @0);
 
-    form = [[FORMGroup alloc] initWithDictionary:@{@"id": @"other_form",
+    group = [[FORMGroup alloc] initWithDictionary:@{@"id": @"other_form",
                                                    @"title": @"Other form"}
                                         position:1
                                         disabled:NO
                                disabledFieldsIDs:nil];
 
-    XCTAssertNotNil(form);
-    XCTAssertEqualObjects(form.formID, @"other_form");
-    XCTAssertEqualObjects(form.title, @"Other form");
-    XCTAssertEqualObjects(form.position, @1);
+    XCTAssertNotNil(group);
+    XCTAssertEqualObjects(group.formID, @"other_form");
+    XCTAssertEqualObjects(group.title, @"Other form");
+    XCTAssertEqualObjects(group.position, @1);
 }
 
 @end


### PR DESCRIPTION
A Form is not a group, because FORMForm sounded weird.

This is the final renaming that started when we went 1.0