### PR TITLE
Improve layout rendering

### DIFF
--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -60,6 +60,7 @@
 
 - (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    CGRect bounds = [[UIScreen mainScreen] hyp_liveBounds];
     UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:indexPath];
 
     BOOL isFirstItemInSection = (indexPath.item == 0);
@@ -73,26 +74,31 @@
 
     NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:indexPath.item - 1 inSection:indexPath.section];
     CGRect previousFrame = [self layoutAttributesForItemAtIndexPath:previousIndexPath].frame;
-    CGFloat previousFrameRightPoint = previousFrame.origin.x + previousFrame.size.width;
-    CGRect currentFrame = attributes.frame;
-
-    CGRect strecthedCurrentFrame = CGRectMake(self.sectionInset.left,
-                                              currentFrame.origin.y,
+    CGRect stretchedCurrentFrame = CGRectMake(self.sectionInset.left,
+                                              attributes.frame.origin.y,
                                               layoutWidth,
-                                              currentFrame.size.height);
+                                              attributes.frame.size.height);
 
-    BOOL isFirstItemInRow = !CGRectIntersectsRect(previousFrame, strecthedCurrentFrame);
+    BOOL isFirstItemInRow = !CGRectIntersectsRect(previousFrame, stretchedCurrentFrame);
 
     if (isFirstItemInRow) {
         [attributes leftAlignFrameWithSectionInset:self.sectionInset];
         return attributes;
+    } else {
+        CGRect frame = attributes.frame;
+        CGFloat previousFrameRightPoint = previousFrame.origin.x + previousFrame.size.width;
+
+        frame.origin.x = previousFrameRightPoint + self.minimumInteritemSpacing;
+
+        BOOL isOutOfBounds = ((frame.origin.x + frame.size.width) > bounds.size.width);
+        if (isOutOfBounds) {
+            frame.origin.x = self.sectionInset.left + self.minimumInteritemSpacing;
+        }
+
+        attributes.frame = frame;
+
+        return attributes;
     }
-
-    CGRect frame = attributes.frame;
-    frame.origin.x = previousFrameRightPoint + self.minimumInteritemSpacing;
-    attributes.frame = frame;
-
-    return attributes;
 }
 
 - (UICollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -106,7 +106,8 @@
                                                                      atIndexPath:(NSIndexPath *)indexPath
 {
     if (![elementKind isEqualToString:UICollectionElementKindSectionHeader]) {
-        return [super layoutAttributesForDecorationViewOfKind:elementKind atIndexPath:indexPath];
+        return [super layoutAttributesForDecorationViewOfKind:elementKind
+                                                  atIndexPath:indexPath];
     } else {
         UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForSupplementaryViewOfKind:elementKind
                                                                                              atIndexPath:indexPath];
@@ -126,7 +127,8 @@
                                                                   atIndexPath:(NSIndexPath *)indexPath
 {
     if (![elementKind isEqualToString:FORMBackgroundKind]) {
-        return [super layoutAttributesForDecorationViewOfKind:elementKind atIndexPath:indexPath];
+        return [super layoutAttributesForDecorationViewOfKind:elementKind
+                                                  atIndexPath:indexPath];
     } else {
         NSMutableArray *fields = [self fieldsAtSection:indexPath.section];
         CGFloat height = 0.0f;
@@ -167,7 +169,8 @@
     for (UICollectionViewLayoutAttributes *element in originalAttributes) {
         if (element.representedElementKind) {
             NSIndexPath *indexPath = element.indexPath;
-            [attributes addObject:[self layoutAttributesForSupplementaryViewOfKind:element.representedElementKind atIndexPath:indexPath]];
+            [attributes addObject:[self layoutAttributesForSupplementaryViewOfKind:element.representedElementKind
+                                                                       atIndexPath:indexPath]];
         } else {
             NSIndexPath *indexPath = element.indexPath;
             [attributes addObject:[self layoutAttributesForItemAtIndexPath:indexPath]];

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -113,6 +113,7 @@
 
     CGRect bounds = [[UIScreen mainScreen] hyp_liveBounds];
     CGRect frame = attributes.frame;
+
     frame.origin.x = FORMHeaderContentMargin;
     frame.size.width = CGRectGetWidth(bounds) - (2 * FORMHeaderContentMargin);
     attributes.frame = frame;
@@ -129,8 +130,18 @@
 
     NSMutableArray *fields = [self fieldsAtSection:indexPath.section];
     CGFloat height = 0.0f;
+
     if (fields.count > 0) {
-        height = [self heightForFields:fields];
+        NSIndexPath *lastIndexPath = [NSIndexPath indexPathForItem:fields.count-1 inSection:indexPath.section];
+        UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:lastIndexPath];
+        height = attributes.frame.origin.y + attributes.frame.size.height - (self.sectionInset.bottom);
+    }
+
+    if (indexPath.section > 0) {
+        NSArray *previousFields = [self fieldsAtSection:indexPath.section - 1];
+        NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:previousFields.count - 1 inSection:indexPath.section-1];
+        UICollectionViewLayoutAttributes *previousAttribute = [super layoutAttributesForItemAtIndexPath:previousIndexPath];
+        height -= previousAttribute.frame.origin.y + previousAttribute.frame.size.height + self.sectionInset.bottom;
     }
 
     CGFloat width = self.collectionViewContentSize.width - (FORMBackgroundViewMargin * 2);

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -132,14 +132,14 @@
     CGFloat height = 0.0f;
 
     if (fields.count > 0) {
-        NSIndexPath *lastIndexPath = [NSIndexPath indexPathForItem:fields.count-1 inSection:indexPath.section];
+        NSIndexPath *lastIndexPath = [NSIndexPath indexPathForItem:fields.count - 1 inSection:indexPath.section];
         UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:lastIndexPath];
         height = attributes.frame.origin.y + attributes.frame.size.height - (self.sectionInset.bottom);
     }
 
     if (indexPath.section > 0) {
         NSArray *previousFields = [self fieldsAtSection:indexPath.section - 1];
-        NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:previousFields.count - 1 inSection:indexPath.section-1];
+        NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:previousFields.count - 1 inSection:indexPath.section - 1];
         UICollectionViewLayoutAttributes *previousAttribute = [super layoutAttributesForItemAtIndexPath:previousIndexPath];
         height -= previousAttribute.frame.origin.y + previousAttribute.frame.size.height + self.sectionInset.bottom;
     }

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -213,42 +213,4 @@
     return fields;
 }
 
-- (CGFloat)heightForFields:(NSArray *)fields
-{
-    CGFloat height = FORMMarginTop + FORMMarginBottom;
-    CGFloat width = 0.0f;
-    FORMField *lastField = [fields lastObject];
-
-    for (FORMField *field in fields) {
-        if (field.sectionSeparator) {
-            height += FORMFieldCellItemSmallHeight;
-
-            BOOL previousSectionIsNotFullWidth = (width > 0.0f && width < 100.0f);
-
-            if (previousSectionIsNotFullWidth) height += FORMFieldCellItemHeight;
-
-            width = 0.0f;
-        } else {
-            width += field.size.width;
-
-            if (width >= 100.0f) {
-                if (field.type == FORMFieldTypeCustom) {
-                    height += field.size.height * FORMFieldCellItemHeight;
-                } else {
-                    height += FORMFieldCellItemHeight;
-                }
-                width = 0.0f;
-            }
-        }
-
-        BOOL isLastFieldAndNotFullWidth = (width > 0.0f &&
-                                           width < 100.0f &&
-                                           [field isEqual:lastField]);
-
-        if (isLastFieldAndNotFullWidth) height += FORMFieldCellItemHeight;
-    }
-
-    return height;
-}
-
 @end

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -126,33 +126,36 @@
 {
     if (![elementKind isEqualToString:FORMBackgroundKind]) {
         return [super layoutAttributesForDecorationViewOfKind:elementKind atIndexPath:indexPath];
+    } else {
+        NSMutableArray *fields = [self fieldsAtSection:indexPath.section];
+        CGFloat height = 0.0f;
+
+        if (fields.count > 0) {
+            NSIndexPath *lastIndexPath = [NSIndexPath indexPathForItem:fields.count - 1 inSection:indexPath.section];
+            UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:lastIndexPath];
+            height = attributes.frame.origin.y + attributes.frame.size.height - (self.sectionInset.bottom);
+        }
+
+        if (indexPath.section > 0) {
+            NSArray *previousFields = [self fieldsAtSection:indexPath.section - 1];
+            NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:previousFields.count - 1 inSection:indexPath.section - 1];
+            UICollectionViewLayoutAttributes *previousAttribute = [super layoutAttributesForItemAtIndexPath:previousIndexPath];
+            height -= previousAttribute.frame.origin.y + previousAttribute.frame.size.height + self.sectionInset.bottom;
+        }
+
+        CGFloat width = self.collectionViewContentSize.width - (FORMBackgroundViewMargin * 2);
+        UICollectionViewLayoutAttributes *attributes = [UICollectionViewLayoutAttributes layoutAttributesForDecorationViewOfKind:elementKind
+                                                                                                                   withIndexPath:indexPath];
+        UICollectionViewLayoutAttributes *headerAttributes = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                                                                                  atIndexPath:indexPath];
+        attributes.frame = CGRectMake(FORMBackgroundViewMargin,
+                                      CGRectGetMaxY(headerAttributes.frame),
+                                      width, height -
+                                      FORMHeaderContentMargin);
+        attributes.zIndex = -1;
+
+        return attributes;
     }
-
-    NSMutableArray *fields = [self fieldsAtSection:indexPath.section];
-    CGFloat height = 0.0f;
-
-    if (fields.count > 0) {
-        NSIndexPath *lastIndexPath = [NSIndexPath indexPathForItem:fields.count - 1 inSection:indexPath.section];
-        UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:lastIndexPath];
-        height = attributes.frame.origin.y + attributes.frame.size.height - (self.sectionInset.bottom);
-    }
-
-    if (indexPath.section > 0) {
-        NSArray *previousFields = [self fieldsAtSection:indexPath.section - 1];
-        NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:previousFields.count - 1 inSection:indexPath.section - 1];
-        UICollectionViewLayoutAttributes *previousAttribute = [super layoutAttributesForItemAtIndexPath:previousIndexPath];
-        height -= previousAttribute.frame.origin.y + previousAttribute.frame.size.height + self.sectionInset.bottom;
-    }
-
-    CGFloat width = self.collectionViewContentSize.width - (FORMBackgroundViewMargin * 2);
-    UICollectionViewLayoutAttributes *attributes = [UICollectionViewLayoutAttributes layoutAttributesForDecorationViewOfKind:elementKind
-                                                                                                               withIndexPath:indexPath];
-    UICollectionViewLayoutAttributes *headerAttributes = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
-                                                                                              atIndexPath:indexPath];
-    attributes.frame = CGRectMake(FORMBackgroundViewMargin, CGRectGetMaxY(headerAttributes.frame), width, height - FORMHeaderContentMargin);
-    attributes.zIndex = -1;
-
-    return attributes;
 }
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect

--- a/Source/FORMLayout.m
+++ b/Source/FORMLayout.m
@@ -70,34 +70,35 @@
         [attributes leftAlignFrameWithSectionInset:self.sectionInset];
 
         return attributes;
-    }
-
-    NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:indexPath.item - 1 inSection:indexPath.section];
-    CGRect previousFrame = [self layoutAttributesForItemAtIndexPath:previousIndexPath].frame;
-    CGRect stretchedCurrentFrame = CGRectMake(self.sectionInset.left,
-                                              attributes.frame.origin.y,
-                                              layoutWidth,
-                                              attributes.frame.size.height);
-
-    BOOL isFirstItemInRow = !CGRectIntersectsRect(previousFrame, stretchedCurrentFrame);
-
-    if (isFirstItemInRow) {
-        [attributes leftAlignFrameWithSectionInset:self.sectionInset];
-        return attributes;
     } else {
-        CGRect frame = attributes.frame;
-        CGFloat previousFrameRightPoint = previousFrame.origin.x + previousFrame.size.width;
+        NSIndexPath *previousIndexPath = [NSIndexPath indexPathForItem:indexPath.item - 1 inSection:indexPath.section];
+        CGRect previousFrame = [self layoutAttributesForItemAtIndexPath:previousIndexPath].frame;
+        CGRect stretchedCurrentFrame = CGRectMake(self.sectionInset.left,
+                                                  attributes.frame.origin.y,
+                                                  layoutWidth,
+                                                  attributes.frame.size.height);
 
-        frame.origin.x = previousFrameRightPoint + self.minimumInteritemSpacing;
+        BOOL isFirstItemInRow = !CGRectIntersectsRect(previousFrame, stretchedCurrentFrame);
 
-        BOOL isOutOfBounds = ((frame.origin.x + frame.size.width) > bounds.size.width);
-        if (isOutOfBounds) {
-            frame.origin.x = self.sectionInset.left + self.minimumInteritemSpacing;
+        if (isFirstItemInRow) {
+            [attributes leftAlignFrameWithSectionInset:self.sectionInset];
+
+            return attributes;
+        } else {
+            CGRect frame = attributes.frame;
+            CGFloat previousFrameRightPoint = previousFrame.origin.x + previousFrame.size.width;
+
+            frame.origin.x = previousFrameRightPoint + self.minimumInteritemSpacing;
+
+            BOOL isOutOfBounds = ((frame.origin.x + frame.size.width) > bounds.size.width);
+            if (isOutOfBounds) {
+                frame.origin.x = self.sectionInset.left + self.minimumInteritemSpacing;
+            }
+
+            attributes.frame = frame;
+
+            return attributes;
         }
-
-        attributes.frame = frame;
-
-        return attributes;
     }
 }
 
@@ -106,19 +107,19 @@
 {
     if (![elementKind isEqualToString:UICollectionElementKindSectionHeader]) {
         return [super layoutAttributesForDecorationViewOfKind:elementKind atIndexPath:indexPath];
+    } else {
+        UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForSupplementaryViewOfKind:elementKind
+                                                                                             atIndexPath:indexPath];
+
+        CGRect bounds = [[UIScreen mainScreen] hyp_liveBounds];
+        CGRect frame = attributes.frame;
+
+        frame.origin.x = FORMHeaderContentMargin;
+        frame.size.width = CGRectGetWidth(bounds) - (2 * FORMHeaderContentMargin);
+        attributes.frame = frame;
+
+        return attributes;
     }
-
-    UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForSupplementaryViewOfKind:elementKind
-                                                                                         atIndexPath:indexPath];
-
-    CGRect bounds = [[UIScreen mainScreen] hyp_liveBounds];
-    CGRect frame = attributes.frame;
-
-    frame.origin.x = FORMHeaderContentMargin;
-    frame.size.width = CGRectGetWidth(bounds) - (2 * FORMHeaderContentMargin);
-    attributes.frame = frame;
-
-    return attributes;
 }
 
 - (UICollectionViewLayoutAttributes *)layoutAttributesForDecorationViewOfKind:(NSString *)elementKind


### PR DESCRIPTION
By taking bounds into account, this should catch fields that try to render themselves off screen by resetting their x position.

- [x] Fix out of bound fields
![screen shot 2015-03-31 at 13 06 21](https://cloud.githubusercontent.com/assets/57446/6917669/edd5c1de-d7a6-11e4-8e7a-9371c20c2edc.PNG)


- [x] Fix height offset in decoration view

**Before**
![before](https://cloud.githubusercontent.com/assets/57446/6918269/9c9249fe-d7ac-11e4-8a65-74354d3a81d6.PNG)

**After**
![after](https://cloud.githubusercontent.com/assets/57446/6918272/a0aaaaea-d7ac-11e4-84dc-e80a3255984c.PNG)


- [x] Clean up