### PR TITLE
Feature: validate `min_value` and `max_value`

### DIFF
--- a/Demos/Basic-ObjC/Basic-ObjC/Assets/forms.json
+++ b/Demos/Basic-ObjC/Basic-ObjC/Assets/forms.json
@@ -258,7 +258,11 @@
                   "type":"field",
                   "action":"update"
                 }
-              ]
+              ],
+              "validations":{
+                "max_value": 100,
+                "min_value": 10
+              }
             },
             {
               "id":"total",

--- a/Source/Cells/Text/FORMTextFieldCell.m
+++ b/Source/Cells/Text/FORMTextFieldCell.m
@@ -194,7 +194,7 @@ static const NSInteger FORMTooltipNumberOfLines = 4;
 
 - (void)validate
 {
-    BOOL validation = ([self.field validate] == FORMValidationResultTypePassed);
+    BOOL validation = ([self.field validate] == FORMValidationResultTypeValid);
     [self.textField setValid:validation];
 }
 

--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -336,7 +336,7 @@
     for (FORMGroup *group in self.groups) {
         for (FORMSection *section in group.sections) {
             for (FORMField *field in section.fields) {
-                BOOL fieldIsValid = (field.validation && [field validate] != FORMValidationResultTypePassed);
+                BOOL fieldIsValid = (field.validation && [field validate] != FORMValidationResultTypeValid);
                 if (fieldIsValid) {
                     [invalidFormFields setObject:field forKey:field.fieldID];
                 }

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -813,7 +813,7 @@ static const CGFloat FORMKeyboardAnimationDuration = 0.3f;
     for (FORMGroup *group in self.formData.groups) {
         for (FORMField *field in group.fields) {
             FORMValidationResultType fieldValidation = [field validate];
-            BOOL requiredFieldFailedValidation = (fieldValidation != FORMValidationResultTypePassed);
+            BOOL requiredFieldFailedValidation = (fieldValidation != FORMValidationResultTypeValid);
             if (requiredFieldFailedValidation) {
                 formIsValid = NO;
             }

--- a/Source/Models/FORMField.h
+++ b/Source/Models/FORMField.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, FORMFieldType) {
 @property (nonatomic) FORMSection *section;
 
 @property (nonatomic) BOOL valid;
-@property (nonatomic) FORMValidationResultType validationType;
+@property (nonatomic) FORMValidationResultType validationResultType;
 @property (nonatomic) BOOL sectionSeparator;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -262,7 +262,7 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
         id dependantFieldValue = field.value;
         self.validationResultType = [validator validateFieldValue:self.value withDependentValue:dependantFieldValue withComparator:self.validation.compareRule];
     }
-    self.valid = (self.validationResultType == FORMValidationResultTypePassed);
+    self.valid = (self.validationResultType == FORMValidationResultTypeValid);
     return self.validationResultType;
 }
 

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -30,7 +30,7 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
 
     _valid = YES;
     _fieldID = remoteID;
-    _validationResultType = FORMValidationResultTypeNone;
+    _validationResultType = FORMValidationResultTypeValid;
     _title = [dictionary andy_valueForKey:@"title"];
     _typeString  = [dictionary andy_valueForKey:@"type"];
     _hidden = [[dictionary andy_valueForKey:@"hidden"] boolValue];

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -30,7 +30,7 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
 
     _valid = YES;
     _fieldID = remoteID;
-    _validationType = FORMValidationResultTypeNone;
+    _validationResultType = FORMValidationResultTypeNone;
     _title = [dictionary andy_valueForKey:@"title"];
     _typeString  = [dictionary andy_valueForKey:@"type"];
     _hidden = [[dictionary andy_valueForKey:@"hidden"] boolValue];
@@ -255,15 +255,15 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
     validatorClass = ([FORMClassFactory classFromString:self.fieldID withSuffix:@"Validator"]) ?: [FORMValidator class];
     validator = [[validatorClass alloc] initWithValidation:self.validation];
 
-    self.validationType = [validator validateFieldValue:self.value];
+    self.validationResultType = [validator validateFieldValue:self.value];
 
     if (self.validation.compareToFieldID.length) {
         FORMField *field = [self.class fieldForFieldID:self.validation.compareToFieldID inSection:self.section];
         id dependantFieldValue = field.value;
-        self.validationType = [validator validateFieldValue:self.value withDependentValue:dependantFieldValue withComparator:self.validation.compareRule];
+        self.validationResultType = [validator validateFieldValue:self.value withDependentValue:dependantFieldValue withComparator:self.validation.compareRule];
     }
-    self.valid = (self.validationType == FORMValidationResultTypePassed);
-    return self.validationType;
+    self.valid = (self.validationResultType == FORMValidationResultTypePassed);
+    return self.validationResultType;
 }
 
 #pragma mark - Public Methods

--- a/Source/Models/FORMFieldValidation.h
+++ b/Source/Models/FORMFieldValidation.h
@@ -3,14 +3,14 @@
 
 @interface FORMFieldValidation : NSObject
 
-@property (nonatomic, getter = isRequired) BOOL required;
-@property (nonatomic) NSNumber *minimumLength;
-@property (nonatomic) NSNumber *maximumLength;
+@property (nonatomic, copy) NSString *compareRule;
+@property (nonatomic, copy) NSString *compareToFieldID;
 @property (nonatomic, copy) NSString *format;
-@property (nonatomic) NSNumber *minimumValue;
+@property (nonatomic) NSNumber *maximumLength;
+@property (nonatomic) NSNumber *minimumLength;
 @property (nonatomic) NSNumber *maximumValue;
-@property (nonatomic) NSString *compareToFieldID;
-@property (nonatomic) NSString *compareRule;
+@property (nonatomic) NSNumber *minimumValue;
+@property (nonatomic, getter = isRequired) BOOL required;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary NS_DESIGNATED_INITIALIZER;
 

--- a/Source/Models/FORMFieldValidation.m
+++ b/Source/Models/FORMFieldValidation.m
@@ -8,22 +8,14 @@
     self = [super init];
     if (!self) return nil;
 
-    self.required = [[dictionary andy_valueForKey:@"required"] boolValue];
-
-    self.minimumLength = 0;
-    if ([dictionary andy_valueForKey:@"min_length"]) {
-        self.minimumLength = [dictionary andy_valueForKey:@"min_length"];
-    }
-
-    self.maximumLength = [dictionary andy_valueForKey:@"max_length"];
-
-    self.format = [dictionary andy_valueForKey:@"format"];
-
-    self.minimumValue = [dictionary andy_valueForKey:@"min_value"];
-
-    self.maximumValue = [dictionary andy_valueForKey:@"max_value"];
     self.compareRule = [dictionary andy_valueForKey:@"compare_rule"];
     self.compareToFieldID = [dictionary andy_valueForKey:@"compare_to"];
+    self.format = [dictionary andy_valueForKey:@"format"];
+    self.maximumLength = [dictionary andy_valueForKey:@"max_length"];
+    self.minimumLength = [dictionary andy_valueForKey:@"min_length"];
+    self.maximumValue = [dictionary andy_valueForKey:@"max_value"];
+    self.minimumValue = [dictionary andy_valueForKey:@"min_value"];
+    self.required = [[dictionary andy_valueForKey:@"required"] boolValue];
 
     return self;
 }

--- a/Source/Validators/FORMBankAccountNumberValidator.m
+++ b/Source/Validators/FORMBankAccountNumberValidator.m
@@ -7,7 +7,7 @@
 - (FORMValidationResultType)validateFieldValue:(id)fieldValue
 {
     FORMValidationResultType superValidation = [super validateFieldValue:fieldValue];
-    if (superValidation != FORMValidationResultTypePassed) return superValidation;
+    if (superValidation != FORMValidationResultTypeValid) return superValidation;
 
     NSString *accountNumber = (NSString *)fieldValue;
     BOOL validationPassed = [HYPNorwegianAccountNumber validateWithString:accountNumber];
@@ -15,7 +15,7 @@
     if (!validationPassed) {
         return FORMValidationResultTypeInvalidBankAccount;
     } else {
-        return FORMValidationResultTypePassed;
+        return FORMValidationResultTypeValid;
     }
 }
 

--- a/Source/Validators/FORMPostalCodeValidator.m
+++ b/Source/Validators/FORMPostalCodeValidator.m
@@ -10,7 +10,7 @@
     if (!postalCodeIsValid) {
         return FORMValidationResultTypeInvalidPostalCode;
     } else {
-        return FORMValidationResultTypePassed;
+        return FORMValidationResultTypeValid;
     }
 }
 

--- a/Source/Validators/FORMSocialSecurityNumberValidator.m
+++ b/Source/Validators/FORMSocialSecurityNumberValidator.m
@@ -7,13 +7,13 @@
 - (FORMValidationResultType)validateFieldValue:(id)fieldValue
 {
     FORMValidationResultType superValidation = [super validateFieldValue:fieldValue];
-    if (superValidation != FORMValidationResultTypePassed) return superValidation;
+    if (superValidation != FORMValidationResultTypeValid) return superValidation;
 
     NSString *SSNString = (NSString *)fieldValue;
     if (![HYPNorwegianSSN validateWithString:SSNString]) {
         return FORMValidationResultTypeInvalidSSN;
     } else {
-        return FORMValidationResultTypePassed;
+        return FORMValidationResultTypeValid;
     }
 }
 

--- a/Source/Validators/FORMValidator.h
+++ b/Source/Validators/FORMValidator.h
@@ -3,18 +3,16 @@
 #import "FORMFieldValidation.h"
 
 typedef NS_ENUM(NSInteger, FORMValidationResultType) {
-    FORMValidationResultTypeNone = 0,
+    FORMValidationResultTypeValid = 0,
     FORMValidationResultTypeInvalid,
     FORMValidationResultTypeInvalidBankAccount,
     FORMValidationResultTypeInvalidEmail,
     FORMValidationResultTypeInvalidFormat,
     FORMValidationResultTypeInvalidPostalCode,
     FORMValidationResultTypeInvalidSSN,
-    FORMValidationResultTypeTooLong,
-    FORMValidationResultTypeTooShort,
-    FORMValidationResultTypeValid,
-    FORMValidationResultTypeValueMissing,
-    FORMValidationResultTypeOther
+    FORMValidationResultTypeInvalidTooLong,
+    FORMValidationResultTypeInvalidTooShort,
+    FORMValidationResultTypeInvalidValueMissing
 };
 
 @interface FORMValidator : NSObject

--- a/Source/Validators/FORMValidator.h
+++ b/Source/Validators/FORMValidator.h
@@ -4,15 +4,16 @@
 
 typedef NS_ENUM(NSInteger, FORMValidationResultType) {
     FORMValidationResultTypeNone = 0,
-    FORMValidationResultTypePassed,
-    FORMValidationResultTypeTooShort,
-    FORMValidationResultTypeTooLong,
-    FORMValidationResultTypeValueMissing,
-    FORMValidationResultTypeInvalidFormat,
-    FORMValidationResultTypeInvalidEmail,
-    FORMValidationResultTypeInvalidSSN,
-    FORMValidationResultTypeInvalidPostalCode,
+    FORMValidationResultTypeInvalid,
     FORMValidationResultTypeInvalidBankAccount,
+    FORMValidationResultTypeInvalidEmail,
+    FORMValidationResultTypeInvalidFormat,
+    FORMValidationResultTypeInvalidPostalCode,
+    FORMValidationResultTypeInvalidSSN,
+    FORMValidationResultTypeTooLong,
+    FORMValidationResultTypeTooShort,
+    FORMValidationResultTypeValid,
+    FORMValidationResultTypeValueMissing,
     FORMValidationResultTypeOther
 };
 

--- a/Source/Validators/FORMValidator.h
+++ b/Source/Validators/FORMValidator.h
@@ -5,6 +5,7 @@
 typedef NS_ENUM(NSInteger, FORMValidationResultType) {
     FORMValidationResultTypeValid = 0,
     FORMValidationResultTypeInvalid,
+    FORMValidationResultTypeInvalidValue,
     FORMValidationResultTypeInvalidBankAccount,
     FORMValidationResultTypeInvalidEmail,
     FORMValidationResultTypeInvalidFormat,

--- a/Source/Validators/FORMValidator.m
+++ b/Source/Validators/FORMValidator.m
@@ -44,6 +44,25 @@
         if (fieldValueIsLonger) return FORMValidationResultTypeInvalidTooLong;
     }
 
+    if (self.validation.minimumValue || self.validation.maximumValue) {
+        CGFloat value = 0.0f;
+        if ([fieldValue isKindOfClass:[NSNumber class]]) {
+            value = [fieldValue floatValue];
+        } else if ([fieldValue isKindOfClass:[NSString class]]) {
+            value = [fieldValue floatValue];
+        }
+
+        if (self.validation.minimumValue) {
+            BOOL valueIsLessThanMinimum = (value < [self.validation.minimumValue floatValue]);
+            if (valueIsLessThanMinimum) return FORMValidationResultTypeInvalidValue;
+        }
+
+        if (self.validation.maximumValue) {
+            BOOL valueIsMoreThanMaximum = (value > [self.validation.maximumValue floatValue]);
+            if (valueIsMoreThanMaximum) return FORMValidationResultTypeInvalidValue;
+        }
+    }
+
     if ([fieldValue isKindOfClass:[NSString class]] && self.validation.format) {
         if (![self validateString:fieldValue withFormat:self.validation.format]) {
             return FORMValidationResultTypeInvalidFormat;

--- a/Source/Validators/FORMValidator.m
+++ b/Source/Validators/FORMValidator.m
@@ -22,12 +22,12 @@
 
 - (FORMValidationResultType)validateFieldValue:(id)fieldValue
 {
-    if (!self.validation) return FORMValidationResultTypePassed;
+    if (!self.validation) return FORMValidationResultTypeValid;
 
     if (!fieldValue && !self.validation.isRequired) return YES;
 
     if ([fieldValue isKindOfClass:[FORMFieldValue class]]) {
-        return FORMValidationResultTypePassed;
+        return FORMValidationResultTypeValid;
     }
 
     if (self.validation.minimumLength > 0) {
@@ -50,34 +50,34 @@
         }
     }
 
-    return FORMValidationResultTypePassed;
+    return FORMValidationResultTypeValid;
 }
 
 - (FORMValidationResultType)validateFieldValue:(id)fieldValue withDependentValue:(id)dependentValue withComparator:(NSString *)comparator
 {
   if ([fieldValue isKindOfClass:[NSDate class]]) {
     if ([comparator isEqualToString:@">"] && [fieldValue laterDate:dependentValue] == fieldValue) {
-      return FORMValidationResultTypePassed;
+      return FORMValidationResultTypeValid;
     }
     else if ([comparator isEqualToString:@"<"] && [fieldValue earlierDate:dependentValue] == fieldValue) {
-      return FORMValidationResultTypePassed;
+      return FORMValidationResultTypeValid;
     }
   }
   
   if ([comparator isEqualToString:@">"] && fieldValue > dependentValue) {
-    return FORMValidationResultTypePassed;
+    return FORMValidationResultTypeValid;
   }
   if ([comparator isEqualToString:@">="] && fieldValue >= dependentValue) {
-    return FORMValidationResultTypePassed;
+    return FORMValidationResultTypeValid;
   }
   if ([comparator isEqualToString:@"<"] && fieldValue < dependentValue) {
-    return FORMValidationResultTypePassed;
+    return FORMValidationResultTypeValid;
   }
   if ([comparator isEqualToString:@"<="] && fieldValue <= dependentValue) {
-    return FORMValidationResultTypePassed;
+    return FORMValidationResultTypeValid;
   }
   if ([comparator isEqualToString:@"=="] && fieldValue == dependentValue) {
-    return FORMValidationResultTypePassed;
+    return FORMValidationResultTypeValid;
   }
   return FORMValidationResultTypeTooShort;
 }

--- a/Source/Validators/FORMValidator.m
+++ b/Source/Validators/FORMValidator.m
@@ -32,16 +32,16 @@
 
     if (self.validation.minimumLength > 0) {
         if (!fieldValue) {
-            return FORMValidationResultTypeValueMissing;
+            return FORMValidationResultTypeInvalidValueMissing;
         } else if ([fieldValue isKindOfClass:[NSString class]]) {
             BOOL fieldValueIsShorter = ([fieldValue length] < [self.validation.minimumLength unsignedIntegerValue]);
-            if (fieldValueIsShorter) return FORMValidationResultTypeTooShort;
+            if (fieldValueIsShorter) return FORMValidationResultTypeInvalidTooShort;
         }
     }
 
     if ([fieldValue isKindOfClass:[NSString class]] && self.validation.maximumLength) {
         BOOL fieldValueIsLonger = ([fieldValue length] > [self.validation.maximumLength unsignedIntegerValue]);
-        if (fieldValueIsLonger) return FORMValidationResultTypeTooLong;
+        if (fieldValueIsLonger) return FORMValidationResultTypeInvalidTooLong;
     }
 
     if ([fieldValue isKindOfClass:[NSString class]] && self.validation.format) {
@@ -63,7 +63,7 @@
       return FORMValidationResultTypeValid;
     }
   }
-  
+
   if ([comparator isEqualToString:@">"] && fieldValue > dependentValue) {
     return FORMValidationResultTypeValid;
   }
@@ -79,7 +79,7 @@
   if ([comparator isEqualToString:@"=="] && fieldValue == dependentValue) {
     return FORMValidationResultTypeValid;
   }
-  return FORMValidationResultTypeTooShort;
+  return FORMValidationResultTypeInvalidTooShort;
 }
 
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14298D6E1ADDA78F00607A49 /* FORMValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 14298D6D1ADDA78F00607A49 /* FORMValidatorTests.m */; };
 		1440AF0D1AC1D76500F15D15 /* FORMGroupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1440AF0C1AC1D76500F15D15 /* FORMGroupTests.m */; };
 		1449AE741AA07E0700BCC40E /* FORMField+Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1449AE731AA07E0700BCC40E /* FORMField+Tests.m */; };
 		144A28BB1A99B2CF004A9086 /* FORMBaseFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 144A28521A99B2CF004A9086 /* FORMBaseFieldCell.m */; };
@@ -83,6 +84,7 @@
 
 /* Begin PBXFileReference section */
 		0F976971F56B077A5DA2E58E /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		14298D6D1ADDA78F00607A49 /* FORMValidatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMValidatorTests.m; sourceTree = "<group>"; };
 		1440AF0C1AC1D76500F15D15 /* FORMGroupTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FORMGroupTests.m; sourceTree = "<group>"; };
 		1449AE721AA07E0700BCC40E /* FORMField+Tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FORMField+Tests.h"; sourceTree = "<group>"; };
 		1449AE731AA07E0700BCC40E /* FORMField+Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FORMField+Tests.m"; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				149C29161A9A23DD00F88B91 /* FORMTargetTests.m */,
 				149C29171A9A23DD00F88B91 /* FORMTests.m */,
 				149C29191A9A23DD00F88B91 /* FORMTextFieldCellTests.m */,
+				14298D6D1ADDA78F00607A49 /* FORMValidatorTests.m */,
 				149C290E1A9A23DD00F88B91 /* Helpers */,
 				149C291A1A9A23DD00F88B91 /* JSONs */,
 				14C4182B1A01919C00636FD6 /* Supporting Files */,
@@ -645,6 +648,7 @@
 				144A28CC1A99B2CF004A9086 /* FORMSocialSecurityNumberFormatter.m in Sources */,
 				144A28D31A99B2CF004A9086 /* FORMBankAccountNumberInputValidator.m in Sources */,
 				144A28BD1A99B2CF004A9086 /* FORMDateFieldCell.m in Sources */,
+				14298D6E1ADDA78F00607A49 /* FORMValidatorTests.m in Sources */,
 				149C29261A9A23DD00F88B91 /* FORMTargetTests.m in Sources */,
 				144A28DE1A99B2CF004A9086 /* FORMFieldValue.m in Sources */,
 				144A28CA1A99B2CF004A9086 /* FORMFormatter.m in Sources */,

--- a/Tests/Tests/FORMDataTests.m
+++ b/Tests/Tests/FORMDataTests.m
@@ -312,7 +312,7 @@
     XCTAssertEqual(FORMValidationResultTypeInvalidFormat, [emailField validate]);
 
     [dataSource reloadWithDictionary:@{@"email" : @"teknologi@hyper.no"}];
-    XCTAssertEqual(FORMValidationResultTypePassed, [emailField validate]);
+    XCTAssertEqual(FORMValidationResultTypeValid, [emailField validate]);
 }
 
 - (void)testFieldWithIDIncludingHiddenFields

--- a/Tests/Tests/FORMValidatorTests.m
+++ b/Tests/Tests/FORMValidatorTests.m
@@ -1,0 +1,10 @@
+@import UIKit;
+@import XCTest;
+
+@interface FORMValidatorTests : XCTestCase
+
+@end
+
+@implementation FORMValidatorTests
+
+@end

--- a/Tests/Tests/FORMValidatorTests.m
+++ b/Tests/Tests/FORMValidatorTests.m
@@ -11,11 +11,13 @@
 
 - (void)testValidateFieldValue
 {
-    FORMFieldValidation *validation = [[FORMFieldValidation alloc] initWithDictionary:@{@"min_value" : @1,
+    FORMFieldValidation *validation = [[FORMFieldValidation alloc] initWithDictionary:@{@"min_value" : @10,
                                                                                         @"max_value" : @100}];
     FORMValidator *validator = [[FORMValidator alloc] initWithValidation:validation];
 
     XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"100"]);
+    XCTAssertEqual(FORMValidationResultTypeInvalidValue, [validator validateFieldValue:@"1"]);
+    XCTAssertEqual(FORMValidationResultTypeInvalidValue, [validator validateFieldValue:@"101"]);
 }
 
 @end

--- a/Tests/Tests/FORMValidatorTests.m
+++ b/Tests/Tests/FORMValidatorTests.m
@@ -1,10 +1,21 @@
 @import UIKit;
 @import XCTest;
 
+#import "FORMValidator.h"
+
 @interface FORMValidatorTests : XCTestCase
 
 @end
 
 @implementation FORMValidatorTests
+
+- (void)testValidateFieldValue
+{
+    FORMFieldValidation *validation = [[FORMFieldValidation alloc] initWithDictionary:@{@"min_value" : @1,
+                                                                                        @"max_value" : @100}];
+    FORMValidator *validator = [[FORMValidator alloc] initWithValidation:validation];
+
+    XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"100"]);
+}
 
 @end

--- a/Tests/Tests/FORMValidatorTests.m
+++ b/Tests/Tests/FORMValidatorTests.m
@@ -16,6 +16,8 @@
     FORMValidator *validator = [[FORMValidator alloc] initWithValidation:validation];
 
     XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"100"]);
+    XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"10"]);
+    XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"50"]);
     XCTAssertEqual(FORMValidationResultTypeInvalidValue, [validator validateFieldValue:@"1"]);
     XCTAssertEqual(FORMValidationResultTypeInvalidValue, [validator validateFieldValue:@"101"]);
 }


### PR DESCRIPTION
Support adding validations with `min_value` and `max_value`.

At the moment `max_value` was used in the input validator but it wasn't used in the `FORMValidator`. Meanwhile `min_value` wasn't been used at all.