### PR TITLE
Fix popover validation failing

### DIFF
--- a/Source/Cells/Popover/FORMPopoverFieldCell.m
+++ b/Source/Cells/Popover/FORMPopoverFieldCell.m
@@ -78,7 +78,8 @@ static const CGFloat FORMIconButtonHeight = 38.0f;
 
 - (void)validate
 {
-    [self.fieldValueLabel setValid:[self.field validate]];
+    BOOL validation = ([self.field validate] == FORMValidationResultTypeValid);
+    [self.fieldValueLabel setValid:validation];
 }
 
 #pragma mark - FORMPopoverFormFieldCell


### PR DESCRIPTION
self.fieldValueLabel’s `setValid:` received a BOOL,

And `[self.field validate]` was sending a `FORMValidationResultType`

Fixes #329