### PR TITLE
Keep null values in the evaluator

### DIFF
--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -949,23 +949,17 @@ includingHiddenFields:(BOOL)includingHiddenFields
     }
 }
 
-- (BOOL)evaluateCondition:(NSString *)condition {
+- (BOOL)evaluateCondition:(NSString *)condition
+{
     BOOL evaluatedResult = NO;
 
     if (condition) {
         NSError *error;
 
-        NSSet *set = [self.values keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
-            return [obj isEqual:[NSNull null]];
-        }];
-
-        NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithDictionary:self.values];
-        [dictionary removeObjectsForKeys:[set allObjects]];
-
         DDExpression *expression = [DDExpression expressionFromString:condition error:&error];
         if (error == nil && self.values) {
             NSNumber *result = [self.evaluator evaluateExpression:expression
-                                                withSubstitutions:dictionary
+                                                withSubstitutions:self.values
                                                             error:&error];
             return [result boolValue];
         }

--- a/Source/Others/DDMathEvaluator+FORM.m
+++ b/Source/Others/DDMathEvaluator+FORM.m
@@ -58,7 +58,8 @@
         NSString *baseKey = [args[0] variable];
         NSString *baseValue = variables[baseKey];
         BOOL baseValueIsPresent = (baseValue || ![baseValue isKindOfClass:[NSNull class]]);
-        NSNumber *present = (baseValueIsPresent) ? @YES : @NO;
+        BOOL isEmptyString = ([baseValue isKindOfClass:[NSString class]] && [baseValue length] < 1);
+        NSNumber *present = (baseValueIsPresent && !isEmptyString) ? @YES : @NO;
 
         return [DDExpression numberExpressionWithNumber:present];
     };
@@ -74,7 +75,8 @@
         NSString *baseKey = [args[0] variable];
         NSString *baseValue = variables[baseKey];
         BOOL baseValueIsMissing = (!baseValue || [baseValue isKindOfClass:[NSNull class]]);
-        NSNumber *missing = (baseValueIsMissing) ? @YES : @NO;
+        BOOL isEmptyString = ([baseValue isKindOfClass:[NSString class]] && [baseValue length] < 1);
+        NSNumber *missing = (baseValueIsMissing || isEmptyString) ? @YES : @NO;
 
         return [DDExpression numberExpressionWithNumber:missing];
     };

--- a/Tests/Tests/FORMDataTests.m
+++ b/Tests/Tests/FORMDataTests.m
@@ -12,6 +12,12 @@
 #import "NSDictionary+ANDYSafeValue.h"
 #import "NSJSONSerialization+ANDYJSONFile.h"
 
+@interface FORMData (FORMDataTests)
+
+- (BOOL)evaluateCondition:(NSString *)condition;
+
+@end
+
 @interface FORMDataTests : XCTestCase
 
 @end
@@ -602,6 +608,31 @@
     NSArray *removedSections = [formData removedSectionsUsingInitialValues:initialValues];
     NSArray *sectionIDs = [removedSections valueForKey:@"sectionID"];
     XCTAssertEqual(sectionIDs.count, 0);
+}
+
+- (void)testTargetConditions {
+
+    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"
+                                                             inBundle:[NSBundle bundleForClass:[self class]]];
+
+    FORMData *formData = [[FORMData alloc] initWithJSON:JSON
+                                          initialValues:@{@"first_name":@"Frank",
+                                                          @"last_name":@"Underwood",
+                                                          @"display_name":@""}
+                                       disabledFieldIDs:nil
+                                               disabled:nil];
+
+    XCTAssertTrue([formData evaluateCondition:@"present($first_name)"]);
+    XCTAssertTrue([formData evaluateCondition:@"present($last_name)"]);
+    XCTAssertFalse([formData evaluateCondition:@"present($display_name)"]);
+
+    XCTAssertFalse([formData evaluateCondition:@"missing($first_name)"]);
+    XCTAssertFalse([formData evaluateCondition:@"missing($last_name)"]);
+    XCTAssertTrue([formData evaluateCondition:@"missing($display_name)"]);
+
+    XCTAssertFalse([formData evaluateCondition:@"equals($first_name, \"Claire\")"]);
+    XCTAssertTrue([formData evaluateCondition:@"equals($last_name, \"Underwood\")"]);
+
 }
 
 @end


### PR DESCRIPTION
I tried adding a rule to a dynamic field but those do not show up in
the dictionary because they are added without an initial value (NSNull).