### PR TITLE
Improve: Validation of non-required fields

### DIFF
--- a/Source/Validators/FORMValidator.m
+++ b/Source/Validators/FORMValidator.m
@@ -22,7 +22,13 @@
 - (FORMValidationResultType)validateFieldValue:(id)fieldValue {
     if (!self.validation) return FORMValidationResultTypeValid;
 
-    if (!fieldValue && self.validation.isRequired) return FORMValidationResultTypeInvalidValueMissing;
+    if (!fieldValue) {
+        if (self.validation.isRequired) {
+            return FORMValidationResultTypeInvalidValueMissing;
+        } else {
+            return FORMValidationResultTypeValid;
+        }
+    }
 
     if ([fieldValue isKindOfClass:[FORMFieldValue class]]) {
         return FORMValidationResultTypeValid;

--- a/Tests/Tests/FORMValidatorTests.m
+++ b/Tests/Tests/FORMValidatorTests.m
@@ -34,11 +34,18 @@
                                                                                         @"max_value" : @100}];
     FORMValidator *validator = [[FORMValidator alloc] initWithValidation:validation];
 
+    XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:nil]);
     XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"100"]);
     XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"10"]);
     XCTAssertEqual(FORMValidationResultTypeValid, [validator validateFieldValue:@"50"]);
     XCTAssertEqual(FORMValidationResultTypeInvalidValue, [validator validateFieldValue:@"1"]);
     XCTAssertEqual(FORMValidationResultTypeInvalidValue, [validator validateFieldValue:@"101"]);
+
+
+    validation = [[FORMFieldValidation alloc] initWithDictionary:@{@"min_value" : @10,
+                                                                   @"required": @YES}];
+    validator = [[FORMValidator alloc] initWithValidation:validation];
+    XCTAssertEqual(FORMValidationResultTypeInvalidValueMissing, [validator validateFieldValue:nil]);
 }
 
 - (void)testFormat {


### PR DESCRIPTION
You can add validation for `max_value` and `min_value`, right now validating an empty value would give you `InvalidFieldType` always, but this is wrong since if it's non-required it shouldn't say that it's `InvalidFieldType`.