### PR TITLE
Improved Login demo app

### DIFF
--- a/Demos/Login-demo/Login-demo/HYPDemoLoginCollectionViewController.m
+++ b/Demos/Login-demo/Login-demo/HYPDemoLoginCollectionViewController.m
@@ -84,32 +84,42 @@
 
 - (void)fieldCell:(UICollectionViewCell *)fieldCell updatedWithField:(FORMField *)field
 {
-    if (self.emailTextField.valid && self.passwordTextField.valid) {
-        FORMButtonFieldCell *cell = (FORMButtonFieldCell *)[self.collectionView cellForItemAtIndexPath:self.indexPathButton];
-        cell.disabled = NO;
-    }
-
-    if ([field.typeString isEqualToString:@"button"]) {
-        [self checkButtonPressedWithField:field];
-    }
+    [self updateLoginButtonState];
+    [self checkButtonPressedWithField:field];
 }
 
 - (void)fieldCell:(UICollectionViewCell *)fieldCell processTargets:(NSArray *)targets { }
 
 #pragma mark - Private methods
 
-- (void)checkButtonPressedWithField:(FORMField *)field
+- (void)updateLoginButtonState
 {
-    if ([field.typeString isEqualToString:@"button"] && self.emailTextField.valid && self.passwordTextField.valid) {
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Hey" message:@"You just logged in! Congratulations" preferredStyle:UIAlertControllerStyleAlert];
-        UIAlertAction *alertActionNice = [UIAlertAction actionWithTitle:@"NICE" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [alertController dismissViewControllerAnimated:YES completion:nil];
-        }];
-
-        [alertController addAction:alertActionNice];
-        [self presentViewController:alertController animated:YES completion:nil];
-    }
+    FORMButtonFieldCell *loginButtonCell = (FORMButtonFieldCell *)[self.collectionView cellForItemAtIndexPath:self.indexPathButton];
+    loginButtonCell.disabled = ![self.dataSource isValid];
 }
 
+- (void)checkButtonPressedWithField:(FORMField *)field
+{
+    if (![field.typeString isEqualToString:@"button"]) {
+        return;
+    }
+    
+    if (![self.dataSource isValid]) {
+        return;
+    }
+    
+    [self showLoginSuccessAlert];
+}
+
+- (void)showLoginSuccessAlert
+{
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Hey" message:@"You just logged in! Congratulations" preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *alertActionNice = [UIAlertAction actionWithTitle:@"NICE" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        [alertController dismissViewControllerAnimated:YES completion:nil];
+    }];
+    
+    [alertController addAction:alertActionNice];
+    [self presentViewController:alertController animated:YES completion:nil];
+}
 
 @end

--- a/Demos/Login-demo/Login-demo/JSON.json
+++ b/Demos/Login-demo/Login-demo/JSON.json
@@ -23,6 +23,7 @@
                         "id":"password",
                         "title":"Password",
                         "type":"password",
+                        "input_type":"password",
                         "size":{
                           "width":60,
                           "height":1


### PR DESCRIPTION
Tweaked the Login demo app to use the password input_type (the password is now secure text).

Also fixed a bug where if you entered valid data in both fields, the login button would be enabled, however if you then cleared one of the fields (making the form invalid), the login button would not be disabled.

Can now close #345 .

Changes:

- added password input_type to the password field in the JSON
- refactored the HYPDemoLoginCollectionViewController slightly
- fixed an issue where the login button would not be disabled after a the form becomes invalid after it  was valid at least once