### PR TITLE
Fix/field empty value

### DIFF
--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -133,6 +133,13 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
             break;
     }
 
+    if ([resultValue isKindOfClass:[NSString class]]) {
+        NSString *value = (NSString *)resultValue;
+        if (!value.length) {
+            resultValue = nil;
+        }
+    }
+
     _value = resultValue;
 }
 

--- a/Tests/Tests/FORMFieldTests.m
+++ b/Tests/Tests/FORMFieldTests.m
@@ -157,4 +157,18 @@
     XCTAssertEqualObjects([field.inputValidator class], [FORMNumberInputValidator class]);
 }
 
+- (void)testEmptyValue {
+    FORMField *field = [[FORMField alloc] initWithDictionary:@{@"id" : @"text",
+                                                               @"type" : @"text"}
+                                                    position:0
+                                                    disabled:NO
+                                           disabledFieldsIDs:nil];
+    field.value = @"Test";
+    XCTAssertEqualObjects(field.value, @"Test");
+
+    field.value = @"";
+    XCTAssertNil(field.value);
+
+}
+
 @end

--- a/Tests/Tests/FORMFieldTests.m
+++ b/Tests/Tests/FORMFieldTests.m
@@ -168,7 +168,6 @@
 
     field.value = @"";
     XCTAssertNil(field.value);
-
 }
 
 @end


### PR DESCRIPTION
When value is an empty string it causes issue with validator where we have condition `if (!fieldValue)`. Imagine the situation when we have not required email field, type something, then clear. Then field was invalid. 