### PR TITLE
Set timezone to GMT before running time tests

### DIFF
--- a/Tests/Tests/FORMFieldTests.m
+++ b/Tests/Tests/FORMFieldTests.m
@@ -17,6 +17,7 @@
 @implementation FORMFieldTests
 
 - (void)testInitWithDictionary {
+    [NSTimeZone setDefaultTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"GMT"]];
     FORMField *field = [[FORMField alloc] initWithDictionary:@{@"id": @"first_name",
                                                                @"title": @"First name",
                                                                @"value": @"John Malkobitch",


### PR DESCRIPTION
Currently, date/time based tests will fail if they are run on machines in certain timezones (e.g., CST).

In order to provide a predictable string to NSDate conversion, this change sets the timezone to GMT for the purpose of testing.