### PR TITLE
Only first dynamic formula working

### DIFF
--- a/Source/FORMData.m
+++ b/Source/FORMData.m
@@ -1031,7 +1031,8 @@ includingHiddenFields:(BOOL)includingHiddenFields
         NSInteger index = [self indexForTemplateSectionWithID:sectionTemplateID inForm:group];
 
         NSDictionary *sectionTemplate = [self.sectionTemplatesDictionary valueForKey:sectionTemplateID];
-        NSMutableDictionary *templateSectionDictionary = [NSMutableDictionary dictionaryWithDictionary:sectionTemplate];
+        NSData *archivedTemplate = [NSKeyedArchiver archivedDataWithRootObject:sectionTemplate];
+        NSMutableDictionary* templateSectionDictionary = [NSKeyedUnarchiver unarchiveObjectWithData:archivedTemplate];
         [templateSectionDictionary setValue:[NSString stringWithFormat:@"%@[%ld]", sectionTemplateID, (long)index] forKey:@"id"];
 
         NSArray *templateFields = [templateSectionDictionary andy_valueForKey:@"fields"];


### PR DESCRIPTION
When the section template was copied for use in the new field section, it was done shallowly. As a result, the template itself was changed when the first field was added.