### PR TITLE
Improve/reload with dictionary

### DIFF
--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -424,7 +424,23 @@ static const CGFloat FORMKeyboardAnimationDuration = 0.3f;
                             BOOL shouldBeNil = ([value isEqual:[NSNull null]]);
 
                             if (field) {
-                                field.value = (shouldBeNil) ? nil : value;
+
+                                if (field.values.count) {
+                                    if (shouldBeNil) {
+                                        field.value = nil;
+                                    } else {
+                                        for (FORMFieldValue *fieldValue in field.values) {
+                                            if ([value isEqual:fieldValue.valueID]) {
+                                                field.value = fieldValue;
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                } else {
+                                    field.value = (shouldBeNil) ? nil : value;
+                                }
+
                                 if (indexPath) {
                                     [updatedIndexPaths addObject:indexPath];
                                 }

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -63,4 +63,4 @@ SPEC CHECKSUMS:
   UIButton-ANDYHighlighted: 3f5e9fb68fb3425bd9fddc030af452d3ac9d1613
   UIViewController-HYPKeyboardToolbar: d5cb85447caeaf9e0e7ed575ce3b1576c7d53dd8
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.37.2

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -199,12 +199,11 @@
     FORMDataSource *dataSource = [[FORMDataSource alloc] initWithJSON:JSON
                                                        collectionView:nil
                                                                layout:nil
-                                                               values:nil
+                                                               values:@{@"username": @0}
                                                              disabled:YES];
 
     [dataSource reloadWithDictionary:@{@"first_name" : @"Elvis",
-                                       @"last_name" : @"Nunez",
-                                       @"username": @0}];
+                                       @"last_name" : @"Nunez"}];
 
     FORMField *field = [dataSource fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertEqualObjects(field.value, @"Elvis Nunez");

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -219,6 +219,9 @@
 
     [dataSource reloadWithDictionary:@{@"username" : @4}];
     XCTAssertNil(usernameValue.value);
+
+    [dataSource reloadWithDictionary:@{@"username" : [NSNull null]}];
+    XCTAssertNil(usernameValue.value);
 }
 
 #pragma mark - testResetDynamicSectionsWithDictionary

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -215,6 +215,10 @@
 
     usernameValue = usernameField.value;
     XCTAssertTrue([usernameValue isKindOfClass:[FORMFieldValue class]]);
+    XCTAssertEqualObjects(usernameValue.valueID, @1);
+
+    [dataSource reloadWithDictionary:@{@"username" : @4}];
+    XCTAssertNil(usernameValue.value);
 }
 
 #pragma mark - testResetDynamicSectionsWithDictionary

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -202,14 +202,18 @@
                                                                values:@{@"username": @0}
                                                              disabled:YES];
 
+    FORMField *usernameField = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
+    FORMFieldValue *usernameValue = usernameField.value;
+    XCTAssertTrue([usernameValue isKindOfClass:[FORMFieldValue class]]);
+
     [dataSource reloadWithDictionary:@{@"first_name" : @"Elvis",
-                                       @"last_name" : @"Nunez"}];
+                                       @"last_name" : @"Nunez",
+                                       @"username" : @1}];
 
     FORMField *field = [dataSource fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertEqualObjects(field.value, @"Elvis Nunez");
 
-    FORMField *usernameField = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
-    FORMFieldValue *usernameValue = usernameField.value;
+    usernameValue = usernameField.value;
     XCTAssertTrue([usernameValue isKindOfClass:[FORMFieldValue class]]);
 }
 

--- a/Tests/Tests/FORMDataSourceTests.m
+++ b/Tests/Tests/FORMDataSourceTests.m
@@ -203,10 +203,15 @@
                                                              disabled:YES];
 
     [dataSource reloadWithDictionary:@{@"first_name" : @"Elvis",
-                                       @"last_name" : @"Nunez"}];
+                                       @"last_name" : @"Nunez",
+                                       @"username": @0}];
 
     FORMField *field = [dataSource fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertEqualObjects(field.value, @"Elvis Nunez");
+
+    FORMField *usernameField = [dataSource fieldWithID:@"username" includingHiddenFields:YES];
+    FORMFieldValue *usernameValue = usernameField.value;
+    XCTAssertTrue([usernameValue isKindOfClass:[FORMFieldValue class]]);
 }
 
 #pragma mark - testResetDynamicSectionsWithDictionary


### PR DESCRIPTION
`reloadWithDictionary:` was setting the literal value to the `FORMField` value.
This PR should fix that by looping through the `values` on the `FORMField` and use the one that matches. If it doesn't match anything in `.values`, it defaults it to `nil`.