### PR TITLE
Refactor FORMFieldValuesTableViewHeader

### DIFF
--- a/Demos/Basic-ObjC/Podfile.lock
+++ b/Demos/Basic-ObjC/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Form (3.5.0):
+  - Form (3.6.0):
     - Hex (~> 1.1.1)
     - HYP8601 (~> 0.7.2)
     - HYPImagePicker (~> 0.3)
@@ -45,7 +45,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Form: c64955d5c33c3e1dd0536d6cb7a0b1e9d567dffc
+  Form: eef64b2bcd1774565069ac3e5cbe91264cc0e799
   Hex: acf6d0dc34658d3d44047a992bfd09190c87e6e7
   HYP8601: 0118757c1332620748c75e7218e7b6b849686d06
   HYPImagePicker: 5c6e463ec15ae6b647355eb11f3f310342616fbf

--- a/Source/Cells/Popover/FORMFieldValuesTableViewHeader.m
+++ b/Source/Cells/Popover/FORMFieldValuesTableViewHeader.m
@@ -13,8 +13,8 @@
 
 #pragma mark - Initializers
 
-- (instancetype)initWithFrame:(CGRect)frame {
-    self = [super initWithFrame:frame];
+- (instancetype)initWithReuseIdentifier:(NSString *)string {
+    self = [super initWithReuseIdentifier:string];
     if (!self) return nil;
 
     [self addSubview:self.titleLabel];

--- a/Source/Cells/Popover/FORMFieldValuesTableViewHeader.m
+++ b/Source/Cells/Popover/FORMFieldValuesTableViewHeader.m
@@ -36,7 +36,7 @@
     _titleLabel.textAlignment = NSTextAlignmentCenter;
     _titleLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
     _titleLabel.numberOfLines = 0;
-    _titleLabel.text = self.field.rawFieldValue;
+    _titleLabel.text = self.field.title;
 
     return _titleLabel;
 }


### PR DESCRIPTION
## Refactor initializer
FORMFieldValuesTableViewHeader is a UITableViewHeaderFooterView so
`initWithFrame` was never called.

The side effect of this was that the subview were never added to the
view.

## Use title instead of rawValue
This was causing issues when running it with a new version of Xcode.

```
[__NSCFNumber isEqualToString:]: unrecognized selector sent to instance
0x7bb73b10
```

The initial value that was assigned to `.text` was a NSNumber and when
it tried to assign it to a string it couldn’t compare the two.