### PR TITLE
Only show info label if it has content

### DIFF
--- a/Source/Cells/Text/FORMTextFieldCell.m
+++ b/Source/Cells/Text/FORMTextFieldCell.m
@@ -273,7 +273,7 @@ static NSString * const FORMTooltipBackgroundColorKey = @"tooltip_background_col
 }
 
 - (void)showTooltip {
-    if (self.field.info && [self.field.info length] > 0 && self.showTooltips) {
+    if (self.field.info && self.field.info.length > 0 && self.showTooltips) {
         self.tooltipView.alpha = 0.0f;
         [self.contentView addSubview:self.tooltipView];
         self.tooltipView.frame = [self tooltipViewFrame];

--- a/Source/Cells/Text/FORMTextFieldCell.m
+++ b/Source/Cells/Text/FORMTextFieldCell.m
@@ -273,7 +273,7 @@ static NSString * const FORMTooltipBackgroundColorKey = @"tooltip_background_col
 }
 
 - (void)showTooltip {
-    if (self.field.info && self.showTooltips) {
+    if (self.field.info && [self.field.info length] > 0 && self.showTooltips) {
         self.tooltipView.alpha = 0.0f;
         [self.contentView addSubview:self.tooltipView];
         self.tooltipView.frame = [self tooltipViewFrame];


### PR DESCRIPTION
When we introduced the localization of `.info` strings, we forgot that we depend on `.info` being empty or not to decide if we should show or the tooltip. This pull request fixes that issue by looking for `.length` of `.info` before displaying it.

Ref; https://github.com/hyperoslo/Form/blob/8f5355368a4d628fa5bcbe517d14798a56b61e8d/Source/Models/FORMField.m#L38-38