### PR TITLE
Section separators should be hidden by default

### DIFF
--- a/CustomField/AppController.swift
+++ b/CustomField/AppController.swift
@@ -24,7 +24,6 @@ class AppController: UIResponder, UIApplicationDelegate {
             rootViewController.navigationBarHidden = true
 
             FORMDefaultStyle.applyStyle()
-            FORMSeparatorView.appearance().setSeparatorColor(UIColor.clearColor())
 
             self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
             self.window?.rootViewController = rootViewController

--- a/Source/Cells/Base/FORMBaseFieldCell.m
+++ b/Source/Cells/Base/FORMBaseFieldCell.m
@@ -47,6 +47,7 @@ static NSString * const FORMHeadingLabelTextColorKey = @"heading_label_text_colo
     if (_separatorView) return _separatorView;
 
     _separatorView = [[FORMSeparatorView alloc] initWithFrame:[self separatorViewFrame]];
+    _separatorView.hidden = YES;
 
     return _separatorView;
 }


### PR DESCRIPTION
Otherwise they show up when creating custom fields

<img width="626" alt="screen shot 2016-01-01 at 18 27 26" src="https://cloud.githubusercontent.com/assets/1088217/12071621/52aa22c0-b0b5-11e5-81b7-3b97bf5a94fe.png">
