### PR TITLE
Improve/decimal separator based on locale

### DIFF
--- a/Source/Formatters/FORMFloatFormatter.m
+++ b/Source/Formatters/FORMFloatFormatter.m
@@ -6,7 +6,9 @@
     string = [super formatString:string reverse:reverse];
     if (!string) return nil;
 
-    if (reverse) {
+    NSString *decimalSeparator = [[NSLocale currentLocale] objectForKey:NSLocaleDecimalSeparator];
+
+    if (reverse || [decimalSeparator isEqualToString:@"."]) {
         return [string stringByReplacingOccurrencesOfString:@"," withString:@"."];
     } else {
         return [string stringByReplacingOccurrencesOfString:@"." withString:@","];

--- a/Source/Input Validators/FORMFloatInputValidator.m
+++ b/Source/Input Validators/FORMFloatInputValidator.m
@@ -8,12 +8,14 @@
 
     if (!valid) return valid;
 
+    NSString *decimalSeparator = [[NSLocale currentLocale] objectForKey:NSLocaleDecimalSeparator];
+
     BOOL hasDelimiter = ([text hyp_containsString:@","] || [text hyp_containsString:@"."]);
-    BOOL stringIsNilOrComma = (!string || [string isEqualToString:@","]);
+    BOOL stringIsNilOrDecimalSeparator = (!string || [string isEqualToString:decimalSeparator]);
 
-    if (hasDelimiter && stringIsNilOrComma) return NO;
+    if (hasDelimiter && stringIsNilOrDecimalSeparator) return NO;
 
-    NSCharacterSet *floatSet = [NSCharacterSet characterSetWithCharactersInString:@"1234567890,"];
+    NSCharacterSet *floatSet = [NSCharacterSet characterSetWithCharactersInString: [NSString stringWithFormat:@"1234567890%@", decimalSeparator]];
     NSCharacterSet *stringSet = [NSCharacterSet characterSetWithCharactersInString:string];
 
     return [floatSet isSupersetOfSet:stringSet];


### PR DESCRIPTION
Change to use NSLocaleDecimalSeparator instead of `,` in
FORMFloatInputValidator floatSet.