### PR TITLE
Add support for Accessibility Labels on text field

### DIFF
--- a/Basic-ObjC/Resources/forms.json
+++ b/Basic-ObjC/Resources/forms.json
@@ -10,6 +10,7 @@
             {
               "id":"first_name",
               "title":"First name",
+              "accessibility_label":"First Name Accessibility Label",
               "info":"Fornavn",
               "type":"name",
               "disabled":true,

--- a/Source/Cells/Button/FORMButtonFieldCell.m
+++ b/Source/Cells/Button/FORMButtonFieldCell.m
@@ -55,6 +55,12 @@ static NSString * const FORMButtonBackgroundColorKey = @"background_color";
     self.button.enabled = !field.disabled;
     self.disabled = field.disabled;
     self.headingLabel.hidden = YES;
+    
+    if ([field.accessibilityLabel length] > 0) {
+        self.button.accessibilityLabel = field.accessibilityLabel;
+    } else {
+        self.button.accessibilityLabel = self.headingLabel.text;
+    }
 
     [self.button setTitle:field.title forState:UIControlStateNormal];
 }

--- a/Source/Cells/Popover/FORMDateFieldCell.m
+++ b/Source/Cells/Popover/FORMDateFieldCell.m
@@ -84,11 +84,19 @@ static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
         self.fieldValueLabel.text = [NSDateFormatter localizedStringFromDate:field.value
                                                                    dateStyle:[self dateStyleForField:field]
                                                                    timeStyle:[self timeStyleForField:field]];
+        
+        self.fieldValueLabel.accessibilityValue = self.fieldValueLabel.text;
     } else {
         self.fieldValueLabel.text = nil;
     }
 
     self.iconImageView.image = [self fieldIcon];
+    
+    if ([field.accessibilityLabel length] > 0) {
+        self.date.accessibilityLabel = field.accessibilityLabel;
+    } else {
+        self.date.accessibilityLabel = self.field.title;
+    }
 }
 
 - (NSDateFormatterStyle)dateStyleForField:(FORMField *)field {

--- a/Source/Cells/Popover/FORMSelectFieldCell.m
+++ b/Source/Cells/Popover/FORMSelectFieldCell.m
@@ -62,6 +62,13 @@ static const NSInteger FORMSelectMaxItemCount = 6;
     } else {
         self.fieldValueLabel.text = nil;
     }
+    
+    if ([field.accessibilityLabel length] > 0) {
+        self.fieldValueLabel.accessibilityLabel = field.accessibilityLabel;
+    } else {
+        self.fieldValueLabel.accessibilityLabel = field.title;
+    }
+    self.fieldValueLabel.accessibilityValue = self.fieldValueLabel.text;
 }
 
 #pragma mark - FORMPopoverFormFieldCell

--- a/Source/Cells/Text/FORMTextFieldCell.m
+++ b/Source/Cells/Text/FORMTextFieldCell.m
@@ -188,6 +188,12 @@ static NSString * const FORMTooltipBackgroundColorKey = @"tooltip_background_col
     self.textField.info            = field.info;
     self.textField.styles          = field.styles;
     self.textField.placeholder     = field.disabled ? nil : field.placeholder;
+    
+    if ([field.accessibilityLabel length] > 0) {
+        self.textField.accessibilityLabel = field.accessibilityLabel;
+    } else {
+        self.textField.accessibilityLabel = self.headingLabel.text;
+    }
 }
 
 - (void)validate {

--- a/Source/Cells/Views/FORMTextField.h
+++ b/Source/Cells/Views/FORMTextField.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSInteger, FORMTextFieldInputType) {
 @property (nonatomic) FORMTextFieldInputType inputType;
 @property (nonatomic, copy) NSString *info;
 @property (nonatomic, copy) NSDictionary *styles;
+@property (nonatomic, copy) NSString *accessibilityLabel;
 
 @property (nonatomic, getter = isValid)    BOOL valid;
 @property (nonatomic, getter = isActive)   BOOL active;

--- a/Source/Models/FORMField.h
+++ b/Source/Models/FORMField.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, FORMFieldType) {
 @property (nonatomic) NSString *formula;
 @property (nonatomic) NSArray *targets;
 @property (nonatomic) NSDictionary *styles;
+@property (nonatomic) NSString *accessibilityLabel;
 
 @property (nonatomic) FORMSection *section;
 

--- a/Source/Models/FORMField.m
+++ b/Source/Models/FORMField.m
@@ -79,6 +79,8 @@ static NSString * const FORMFormatterSelector = @"formatString:reverse:";
     NSDictionary *styles = [dictionary andy_valueForKey:@"styles"];
 
     _styles = styles;
+    
+    _accessibilityLabel = NSLocalizedString([dictionary andy_valueForKey:@"accessibility_label"], nil);
 
     BOOL shouldDisable = (disabled || [disabledFieldsIDs containsObject:_fieldID]);
 

--- a/Source/Models/FORMFieldValue.h
+++ b/Source/Models/FORMFieldValue.h
@@ -11,6 +11,7 @@
 @property (nonatomic) FORMField *field;
 @property (nonatomic) NSNumber *value;
 @property (nonatomic) BOOL defaultValue;
+@property (nonatomic, copy) NSString *accessibilityLabel;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary;
 

--- a/Source/Models/FORMFieldValue.m
+++ b/Source/Models/FORMFieldValue.m
@@ -15,7 +15,8 @@
     _info = NSLocalizedString([dictionary andy_valueForKey:@"info"], nil);
     _value = [dictionary andy_valueForKey:@"value"];
     _defaultValue = [[dictionary andy_valueForKey:@"default"] boolValue];
-
+    _accessibilityLabel = NSLocalizedString([dictionary andy_valueForKey:@"accessibility_label"], nil);
+    
     NSMutableArray *targets = [NSMutableArray new];
 
     for (NSDictionary *targetDict in [dictionary andy_valueForKey:@"targets"]) {

--- a/Tests/FORMFieldTests.m
+++ b/Tests/FORMFieldTests.m
@@ -22,6 +22,7 @@
                                                                @"title": @"First name",
                                                                @"placeholder": @"placeholder",
                                                                @"info": @"info",
+                                                               @"accessibility_label": @"Accessibility label",
                                                                @"value": @"John Malkobitch",
                                                                @"type": @"name",
                                                                @"size": @{@"width": @30,
@@ -41,6 +42,7 @@
     XCTAssertEqualObjects(field.info, @"info");
     XCTAssertEqualObjects(field.value, @"John Malkobitch");
     XCTAssertEqualObjects(field.typeString, @"name");
+    XCTAssertEqualObjects(field.accessibilityLabel, @"Accessibility label");
     XCTAssertTrue(field.type == FORMFieldTypeText);
     XCTAssertTrue(CGSizeEqualToSize(field.size, CGSizeMake(30, 1)));
     XCTAssertFalse(field.disabled);

--- a/Tests/FORMFieldTests.m
+++ b/Tests/FORMFieldTests.m
@@ -51,6 +51,7 @@
 
     field = [[FORMField alloc] initWithDictionary:@{@"id": @"start_date",
                                                     @"title": @"Start date",
+                                                    @"accessibility_label": @"Accessibility label",
                                                     @"type": @"date",
                                                     @"minimum_date":@"2000-01-01T00:00:00.002Z",
                                                     @"maximum_date":@"2015-01-01T00:00:00.002Z",
@@ -68,6 +69,7 @@
     XCTAssertEqualObjects([field.minimumDate hyp_dateString], @"2000-01-01");
     XCTAssertEqualObjects([field.maximumDate hyp_dateString], @"2015-01-01");
     XCTAssertEqualObjects([field.value hyp_dateString], @"2014-01-01");
+    XCTAssertEqualObjects(field.accessibilityLabel, @"Accessibility label");
 
     XCTAssertTrue(CGSizeEqualToSize(field.size, CGSizeMake(10, 4)));
     XCTAssertTrue(field.disabled);
@@ -76,6 +78,7 @@
 
     field = [[FORMField alloc] initWithDictionary:@{@"id": @"start_time",
                                                     @"title": @"Start time",
+                                                    @"accessibility_label": @"Accessibility label",
                                                     @"type": @"time",
                                                     @"minimum_date":@"2000-01-01T00:00:00.002Z",
                                                     @"maximum_date":@"2015-01-01T00:00:00.002Z",
@@ -93,6 +96,7 @@
     XCTAssertEqualObjects([field.minimumDate hyp_dateString], @"2000-01-01");
     XCTAssertEqualObjects([field.maximumDate hyp_dateString], @"2015-01-01");
     XCTAssertEqualObjects([field.value hyp_dateString], @"2014-01-01");
+    XCTAssertEqualObjects(field.accessibilityLabel, @"Accessibility label");
 
     XCTAssertTrue(CGSizeEqualToSize(field.size, CGSizeMake(10, 4)));
     XCTAssertTrue(field.disabled);
@@ -102,6 +106,7 @@
 
     field = [[FORMField alloc] initWithDictionary:@{@"id": @"dateAndTime",
                                                     @"title": @"Date and Time",
+                                                    @"accessibility_label": @"Accessibility label",
                                                     @"type": @"date_time",
                                                     @"minimum_date":@"2002-01-01T00:00:00.002Z",
                                                     @"maximum_date":@"2013-01-01T00:00:00.002Z",
@@ -119,9 +124,38 @@
     XCTAssertEqualObjects([field.minimumDate hyp_dateString], @"2002-01-01");
     XCTAssertEqualObjects([field.maximumDate hyp_dateString], @"2013-01-01");
     XCTAssertEqualObjects([field.value hyp_dateString], @"2011-01-01");
+    XCTAssertEqualObjects(field.accessibilityLabel, @"Accessibility label");
 
     XCTAssertTrue(CGSizeEqualToSize(field.size, CGSizeMake(15, 2)));
     XCTAssertFalse(field.disabled);
+    XCTAssertNil(field.validation);
+    XCTAssertFalse(field.hidden);
+    
+    NSArray *values = @[
+                        @{@"id": @0, @"title": @"Permanent"},
+                        @{@"id": @1, @"title": @"Temporary"},
+                      ];
+    field = [[FORMField alloc] initWithDictionary:@{@"id": @"contract_type",
+                                                    @"title": @"Contract type",
+                                                    @"accessibility_label": @"Accessibility label",
+                                                    @"type": @"select",
+                                                    @"values":values,
+                                                    @"value":@0,
+                                                    @"size": @{@"width": @10,
+                                                               @"height": @4}
+                                                    }
+                                         position:1
+                                         disabled:NO
+                                disabledFieldsIDs:@[@"contract_type"]];
+    XCTAssertNotNil(field);
+    XCTAssertEqualObjects(field.typeString, @"select");
+    XCTAssertTrue(field.type == FORMFieldTypeSelect);
+    
+    XCTAssertEqualObjects(field.value, @0);
+    XCTAssertEqualObjects(field.accessibilityLabel, @"Accessibility label");
+    
+    XCTAssertTrue(CGSizeEqualToSize(field.size, CGSizeMake(10, 4)));
+    XCTAssertTrue(field.disabled);
     XCTAssertNil(field.validation);
     XCTAssertFalse(field.hidden);
 }

--- a/Tests/FORMFieldValueTests.m
+++ b/Tests/FORMFieldValueTests.m
@@ -12,12 +12,14 @@
     FORMFieldValue *fieldValue = [[FORMFieldValue alloc] initWithDictionary:@{@"id": @"contract_type",
                                                                               @"title": @"Contract Type",
                                                                               @"info": @"This is ma' contract",
+                                                                              @"accessibility_label": @"Accessibility label",
                                                                               @"value": @1,
                                                                               @"default": @YES}];
     XCTAssertNotNil(fieldValue);
     XCTAssertEqualObjects(fieldValue.valueID, @"contract_type");
     XCTAssertEqualObjects(fieldValue.title, @"Contract Type");
     XCTAssertEqualObjects(fieldValue.info, @"This is ma' contract");
+    XCTAssertEqualObjects(fieldValue.accessibilityLabel, @"Accessibility label");
     XCTAssertEqualObjects(fieldValue.value, @1);
     XCTAssertTrue(fieldValue.defaultValue);
 


### PR DESCRIPTION
This adds support for setting the `accessibilityLabel` attribute on UITextField through JSON.

**Attribute Name:** `accessibility_label`
**Applies To:** Text type fields

**Usage**
```json
{
  "id":"first_name",
  "title":"First name",
  "accessibility_label":"First Name Accessibility Label",
  "type":"text",
  "size":{
    "width":30,
    "height":1
  }
}
```

The field's `title` attribute will be used for the accessibility label in the event one is not provided.