### PR TITLE
Fix/ipad popovers

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,4 +1,0 @@
-ci_service: travis_ci
-coverage_service: coveralls
-xcodeproj: Demo.xcodeproj
-source_directory: Source

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ osx_image: xcode8
 language: objective-c
 cache: cocoapods
 before_install:
-- travis_wait 35; pod install
+- travis_wait 35; pod update
 script:
 - xcodebuild clean build -workspace Demo.xcworkspace -scheme "Tests"  -sdk iphonesimulator | xcpretty
 - xcodebuild test -project -workspace Demo.xcworkspace -scheme "Tests" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-osx_image: xcode7.3
+osx_image: xcode8
 language: objective-c
 cache: cocoapods
-script: xcodebuild -workspace Demo.xcworkspace -scheme Tests -sdk iphonesimulator build test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test | xcpretty -c && exit ${PIPESTATUS[0]}
+before_install:
+- travis_wait 35; pod install
+script:
+- xcodebuild clean build -workspace Demo.xcworkspace -scheme "Tests"  -sdk iphonesimulator | xcpretty
+- xcodebuild test -project -workspace Demo.xcworkspace -scheme "Tests" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -378,7 +378,6 @@
 		14BD56211BEA57920043A673 /* HYPDemoLoginCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HYPDemoLoginCollectionViewController.m; sourceTree = "<group>"; };
 		14BD56221BEA57920043A673 /* JSON.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = JSON.json; sourceTree = "<group>"; };
 		14BD56261BEA57FE0043A673 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		14C0AF7F1BD6D4230009ECBE /* .slather.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .slather.yml; sourceTree = "<group>"; };
 		14C0AF801BD6D4230009ECBE /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		14C0AF811BD6D4230009ECBE /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		14C0AF821BD6D4230009ECBE /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
@@ -982,7 +981,6 @@
 		14C136501AB7849300B7B07A /* Metadata */ = {
 			isa = PBXGroup;
 			children = (
-				14C0AF7F1BD6D4230009ECBE /* .slather.yml */,
 				14C0AF801BD6D4230009ECBE /* .travis.yml */,
 				14C0AF811BD6D4230009ECBE /* CHANGELOG.md */,
 				14C0AF821BD6D4230009ECBE /* CONTRIBUTING.md */,

--- a/Source/Cells/Popover/FORMDateFieldCell.m
+++ b/Source/Cells/Popover/FORMDateFieldCell.m
@@ -1,7 +1,8 @@
 #import "FORMDateFieldCell.h"
 #import "FORMFieldValue.h"
 
-static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
+static const CGSize FORMDatePadPopoverSize = { 320.0f, 284.0f };
+static const CGSize FORMDatePhonePopoverSize = { 320.0f, 200.0f };
 
 @interface FORMDateFieldCell () <FORMTextFieldDelegate, FORMFieldValuesTableViewControllerDelegate>
 
@@ -14,8 +15,10 @@ static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
 #pragma mark - Initializers
 
 - (instancetype)initWithFrame:(CGRect)frame {
+    CGSize popoverSize = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? FORMDatePadPopoverSize : FORMDatePhonePopoverSize;
+
     self = [super initWithFrame:frame contentViewController:self.fieldValuesController
-                 andContentSize:FORMDatePopoverSize];
+                 andContentSize:popoverSize];
     if (!self) return nil;
 
     self.fieldValuesController.delegate = self;
@@ -29,12 +32,15 @@ static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
 #pragma mark - Getters
 
 - (CGRect)datePickerFrame {
-    CGFloat x = 0;
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
-        CGRect bounds = [[UIScreen mainScreen] bounds];
-        x = (bounds.size.width - FORMDatePopoverSize.width) / 2.0;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        return CGRectMake(0.0f, 25.0f, FORMDatePadPopoverSize.width, 196);
     }
-    return CGRectMake(x, 25.0f, FORMDatePopoverSize.width, FORMDatePopoverSize.height);
+
+    CGFloat x = 0;
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+    x = (bounds.size.width - FORMDatePhonePopoverSize.width) / 2.0;
+
+    return CGRectMake(x, 25.0f, FORMDatePhonePopoverSize.width, FORMDatePhonePopoverSize.height);
 }
 
 - (UIDatePicker *)datePicker {
@@ -80,18 +86,32 @@ static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
 - (void)updateWithField:(FORMField *)field {
     [super updateWithField:field];
 
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        FORMFieldValue *confirmValue = [FORMFieldValue new];
+        confirmValue.title = NSLocalizedString(@"Confirm", nil);
+        confirmValue.valueID = [NSDate date];
+        confirmValue.value = @YES;
+
+        FORMFieldValue *clearValue = [FORMFieldValue new];
+        clearValue.title = NSLocalizedString(@"Clear", nil);
+        clearValue.valueID = [NSDate date];
+        clearValue.value = @NO;
+
+        field.values = @[confirmValue, clearValue];
+    }
+
     if (field.value) {
         self.fieldValueLabel.text = [NSDateFormatter localizedStringFromDate:field.value
                                                                    dateStyle:[self dateStyleForField:field]
                                                                    timeStyle:[self timeStyleForField:field]];
-        
+
         self.fieldValueLabel.accessibilityValue = self.fieldValueLabel.text;
     } else {
         self.fieldValueLabel.text = nil;
     }
 
     self.iconImageView.image = [self fieldIcon];
-    
+
     if ([field.accessibilityLabel length] > 0) {
         self.date.accessibilityLabel = field.accessibilityLabel;
     } else {
@@ -139,13 +159,13 @@ static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
         case FORMFieldTypeDate:
         case FORMFieldTypeDateTime:
             return [UIImage imageNamed:@"calendar"
-                                  inBundle:bundle
-             compatibleWithTraitCollection:trait];
+                              inBundle:bundle
+         compatibleWithTraitCollection:trait];
             break;
         case FORMFieldTypeTime:
             return [UIImage imageNamed:@"clock"
                               inBundle:bundle
-         compatibleWithTraitCollection:trait];
+            compatibleWithTraitCollection:trait];
             break;
         default:
             return nil;
@@ -157,8 +177,9 @@ static const CGSize FORMDatePopoverSize = { 320.0f, 200.0f };
 
 - (void)updateContentViewController:(UIViewController *)contentViewController withField:(FORMField *)field {
     self.fieldValuesController.field = self.field;
-    
-    contentViewController.preferredContentSize = FORMDatePopoverSize;
+
+    CGSize popoverSize = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? FORMDatePadPopoverSize : FORMDatePhonePopoverSize;
+    contentViewController.preferredContentSize = popoverSize;
 
     if (self.field.info) {
         CGRect frame = self.datePicker.frame;

--- a/Source/Cells/Popover/FORMFieldValuesTableViewController.m
+++ b/Source/Cells/Popover/FORMFieldValuesTableViewController.m
@@ -14,11 +14,11 @@
 #pragma mark - Getters
 
 - (FORMFieldValuesTableViewHeader *)headerView {
-	if (_headerView) return _headerView;
+    if (_headerView) return _headerView;
 
     _headerView = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:FORMFieldValuesTableViewHeaderIdentifier];
 
-	return _headerView;
+    return _headerView;
 }
 
 #pragma mark - Setters
@@ -26,18 +26,21 @@
 - (void)setField:(FORMField *)field {
     _field = field;
 
-    UIBarButtonItem *clear = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Clear", nil) style:UIBarButtonItemStylePlain target:self action:@selector(clearButtonDidTap)];
-    BOOL shouldShowDoneButton = (_field.type == FORMFieldTypeDate || _field.type == FORMFieldTypeDateTime || _field.type == FORMFieldTypeTime);
-    if (shouldShowDoneButton) {
-        UIBarButtonItem *done = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonDidTap)];
-        self.navigationItem.rightBarButtonItems = @[done, clear];
-    } else {
-        self.navigationItem.rightBarButtonItem = clear;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        UIBarButtonItem *clear = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Clear", nil) style:UIBarButtonItemStylePlain target:self action:@selector(clearButtonDidTap)];
+        BOOL shouldShowDoneButton = (_field.type == FORMFieldTypeDate || _field.type == FORMFieldTypeDateTime || _field.type == FORMFieldTypeTime);
+        if (shouldShowDoneButton) {
+            UIBarButtonItem *done = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonDidTap)];
+            self.navigationItem.rightBarButtonItems = @[done, clear];
+        } else {
+            self.navigationItem.rightBarButtonItem = clear;
+        }
+
+        self.title = self.field.title;
     }
 
     self.values = [NSArray arrayWithArray:field.values];
     self.headerView.field = field;
-    self.title = self.field.title;
     [self.tableView reloadData];
 }
 
@@ -53,8 +56,10 @@
     [self.tableView registerClass:[FORMFieldValueCell class] forCellReuseIdentifier:FORMFieldValueCellIdentifer];
     [self.tableView registerClass:[FORMFieldValuesTableViewHeader class] forHeaderFooterViewReuseIdentifier:FORMFieldValuesTableViewHeaderIdentifier];
 
-    UIBarButtonItem *cancel = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonDidTap)];
-    self.navigationItem.leftBarButtonItem = cancel;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        UIBarButtonItem *cancel = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonDidTap)];
+        self.navigationItem.leftBarButtonItem = cancel;
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -69,7 +74,7 @@
 #pragma mark - Navigation Buttons Actions
 
 - (void)cancelButtonDidTap {
-  [self dismissViewControllerAnimated:YES completion:nil];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)doneButtonDidTap {
@@ -108,6 +113,8 @@
     } else if (self.field.info) {
         [self.headerView setField:self.field];
         headerHeight = [self.headerView labelHeight];
+    } else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        headerHeight = FORMFieldValuesCellHeight;
     }
 
     return headerHeight;

--- a/Source/Cells/Popover/FORMFieldValuesTableViewHeader.h
+++ b/Source/Cells/Popover/FORMFieldValuesTableViewHeader.h
@@ -17,5 +17,7 @@ static NSString * const FORMFieldValuesTableViewHeaderIdentifier = @"FORMFieldVa
 
 - (void)setInfoLabelFont:(UIFont *)infoLabelFont UI_APPEARANCE_SELECTOR;
 - (void)setInfoLabelTextColor:(UIColor *)infoLabelTextColor UI_APPEARANCE_SELECTOR;
+- (void)setTitleLabelFont:(UIFont *)titleLabelFont UI_APPEARANCE_SELECTOR;
+- (void)setTitleLabelTextColor:(UIColor *)titleLabelTextColor UI_APPEARANCE_SELECTOR;
 
 @end

--- a/Source/Cells/Popover/FORMFieldValuesTableViewHeader.m
+++ b/Source/Cells/Popover/FORMFieldValuesTableViewHeader.m
@@ -4,6 +4,7 @@
 
 @interface FORMFieldValuesTableViewHeader ()
 
+@property (nonatomic) UILabel *titleLabel;
 @property (nonatomic) UILabel *infoLabel;
 
 @end
@@ -16,21 +17,44 @@
     self = [super initWithReuseIdentifier:string];
     if (!self) return nil;
 
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        [self addSubview:self.titleLabel];
+    }
+
     [self addSubview:self.infoLabel];
 
     return self;
 }
 
 #pragma mark - Getters
+- (CGRect)titleLabelFrame {
+    return CGRectMake(0.0f, FORMInfoLabelY, FORMFieldValuesHeaderWidth, FORMLabelHeight);
+}
+
+- (UILabel *)titleLabel {
+    if (_titleLabel) return _titleLabel;
+
+    _titleLabel = [[UILabel alloc] initWithFrame:[self titleLabelFrame]];
+    _titleLabel.textAlignment = NSTextAlignmentCenter;
+    _titleLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
+    _titleLabel.numberOfLines = 0;
+    _titleLabel.text = self.field.title;
+
+    return _titleLabel;
+}
 
 - (CGRect)infoLabelFrame {
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        CGFloat y = CGRectGetMaxY(self.titleLabel.frame);
+        return CGRectMake(0.0f, y, FORMFieldValuesHeaderWidth, FORMLabelHeight * 1.1);
+    }
+
     CGFloat x = 0;
     CGFloat width = FORMFieldValuesHeaderWidth;
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
-        CGRect bounds = [[UIScreen mainScreen] bounds];
-        width = bounds.size.width;
-        x = (width - FORMFieldValuesHeaderWidth) / 2.0;
-    }
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+    width = bounds.size.width;
+    x = (width - FORMFieldValuesHeaderWidth) / 2.0;
+
     return CGRectMake(x, FORMInfoLabelY, width, FORMLabelHeight * 1.1);
 }
 
@@ -48,6 +72,12 @@
 - (CGFloat)labelHeight
 {
     CGFloat height = 0.0f;
+
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        height += self.titleLabel.frame.origin.y * 2;
+        height += self.titleLabel.frame.size.height;
+    }
+
     height += self.infoLabel.frame.size.height;
 
     return height;
@@ -58,9 +88,25 @@
 - (void)setField:(FORMField *)field {
     _field = field;
 
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        self.titleLabel.text = field.title;
+    }
+
     self.infoLabel.text = field.info;
 
     [self updateLabelFrames];
+}
+
+- (void)setTitleLabelFont:(UIFont *)titleLabelFont {
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        self.titleLabel.font = titleLabelFont;
+    }
+}
+
+- (void)setTitleLabelTextColor:(UIColor *)titleLabelTextColor {
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        self.titleLabel.textColor = titleLabelTextColor;
+    }
 }
 
 - (void)setInfoLabelFont:(UIFont *)infoLabelFont {
@@ -74,11 +120,23 @@
 #pragma marks - Private methods
 
 - (void)updateLabelFrames {
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        [self.titleLabel sizeToFit];
+        CGRect titleFrame = self.titleLabel.frame;
+        titleFrame.size.width = FORMFieldValuesHeaderWidth;
+        self.titleLabel.frame = titleFrame;
+    }
+
     [self.infoLabel sizeToFit];
     CGRect infoFrame = self.infoLabel.frame;
     infoFrame.origin.y = [self infoLabelFrame].origin.y;
     infoFrame.size.width = FORMFieldValuesHeaderWidth;
     infoFrame.size.height = self.infoLabel.frame.size.height + 10.0;
+
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        infoFrame.size.height = self.infoLabel.frame.size.height + 10.0;
+    }
+    
     self.infoLabel.frame = infoFrame;
 }
 

--- a/Source/Cells/Popover/FORMPopoverFieldCell.m
+++ b/Source/Cells/Popover/FORMPopoverFieldCell.m
@@ -127,6 +127,18 @@ static const CGFloat FORMIconButtonHeight = 38.0f;
 
     [self updateContentViewController:self.contentViewController withField:self.field];
 
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        self.contentViewController.modalPresentationStyle = UIModalPresentationPopover;
+        UIPopoverPresentationController *presentationController = [self.contentViewController popoverPresentationController];
+        presentationController.sourceView = self;
+        presentationController.sourceRect = self.bounds;
+
+        UIViewController *topViewController = [UIViewController hyp_topViewController];
+        [topViewController presentViewController:self.contentViewController animated:YES completion:nil];
+        return;
+    }
+
+
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.contentViewController];
 
     navigationController.modalPresentationStyle = UIModalPresentationPopover;

--- a/Source/Cells/Popover/FORMSelectFieldCell.m
+++ b/Source/Cells/Popover/FORMSelectFieldCell.m
@@ -62,7 +62,7 @@ static const NSInteger FORMSelectMaxItemCount = 6;
     } else {
         self.fieldValueLabel.text = nil;
     }
-    
+
     if ([field.accessibilityLabel length] > 0) {
         self.fieldValueLabel.accessibilityLabel = field.accessibilityLabel;
     } else {

--- a/Source/FORMDefaultStyle.m
+++ b/Source/FORMDefaultStyle.m
@@ -25,7 +25,7 @@
 
     [[FORMBackgroundView appearance] setBackgroundColor:[[UIColor alloc] initWithHex:@"DAE2EA"]];
     [[FORMBackgroundView appearance] setGroupBackgroundColor:[[UIColor alloc] initWithHex:@"DAE2EA"]];
-    
+
     [[FORMSeparatorView appearance] setSeparatorColor:[[UIColor alloc] initWithHex:@"C6C6C6"]];
 
     [[FORMButtonFieldCell appearance] setBackgroundColor:[[UIColor alloc] initWithHex:@"3DAFEB"]];
@@ -93,17 +93,19 @@
     [[FORMGroupHeaderView appearance] setHeaderLabelTextColor:[[UIColor alloc] initWithHex:@"455C73"]];
     [[FORMGroupHeaderView appearance] setHeaderBackgroundColor:[UIColor whiteColor]];
 
+    [[FORMFieldValuesTableViewHeader appearance] setTitleLabelFont:[UIFont fontWithName:@"AvenirNext-Medium" size:17.0]];
+    [[FORMFieldValuesTableViewHeader appearance] setTitleLabelTextColor:[[UIColor alloc] initWithHex:@"455C73"]];
     [[FORMFieldValuesTableViewHeader appearance] setInfoLabelFont:[UIFont fontWithName:@"AvenirNext-UltraLight" size:17.0]];
     [[FORMFieldValuesTableViewHeader appearance] setInfoLabelTextColor:[[UIColor alloc] initWithHex:@"28649C"]];
 
     [[FORMTextFieldCell appearance] setTooltipLabelFont:[UIFont fontWithName:@"AvenirNext-Medium" size:14.0]];
     [[FORMTextFieldCell appearance] setTooltipLabelTextColor:[[UIColor alloc] initWithHex:@"97591D"]];
     [[FORMTextFieldCell appearance] setTooltipBackgroundColor:[[UIColor alloc] initWithHex:@"FDFD54"]];
-    
+
     [[FORMSegmentFieldCell appearance] setLabelFont:[UIFont fontWithName:@"AvenirNext-DemiBold" size:16.0]];
     [[FORMSegmentFieldCell appearance] setBackgroundColor:[[UIColor alloc] initWithHex:@"FFFFFF"]];
     [[FORMSegmentFieldCell appearance] setTintColor:[[UIColor alloc] initWithHex:@"3DAFEB"]];
-
+    
 }
 
 @end


### PR DESCRIPTION
Feature introduced in https://github.com/hyperoslo/Form/pull/479 caused some issues in popover view on iPad, such us:
- Long titles were cut for the date field because of 3 buttons in the navigation bar;
- Clear button should not be displayed for every select field.

This PR reverts to old popover UI on iPad, so the feature with navigation controller will be used only on iPhone. It's more a "hotfix", so this functionality could be re-designed and changed later if needed. 