### PR TITLE
Remove abort() call to prevent crash on select clear

### DIFF
--- a/Source/Models/FORMFieldValue.m
+++ b/Source/Models/FORMFieldValue.m
@@ -42,8 +42,6 @@
         return [self.valueID isEqualToNumber:identifier];
     } else if ([self.valueID isKindOfClass:[NSDate class]]) {
         return [self.valueID isEqualToDate:identifier];
-    } else {
-        abort();
     }
 
     return NO;

--- a/Source/Models/FORMFieldValue.m
+++ b/Source/Models/FORMFieldValue.m
@@ -34,7 +34,7 @@
 }
 
 - (BOOL)identifierIsEqualTo:(id)identifier {
-    if (!identifier) return NO;
+    if (!identifier || !self.valueID) return NO;
 
     if ([self.valueID isKindOfClass:[NSString class]]) {
         return [self.valueID isEqualToString:identifier];
@@ -42,6 +42,8 @@
         return [self.valueID isEqualToNumber:identifier];
     } else if ([self.valueID isKindOfClass:[NSDate class]]) {
         return [self.valueID isEqualToDate:identifier];
+    } else {
+        abort();
     }
 
     return NO;


### PR DESCRIPTION
When a select field is cleared using the "clear" button, subsequent access causes `- (BOOL)identifierIsEqualTo:(id)identifier` to hit the `else` condition which calls `abort()`.

This removes the `else` condition and allows the method to return `NO`.