### PR TITLE
Disable collectionView bounces to prevent NSRangeException

### DIFF
--- a/Source/FORMViewController.m
+++ b/Source/FORMViewController.m
@@ -41,6 +41,8 @@
         [self.collectionView numberOfSections];
     }
 
+    self.collectionView.bounces = NO;
+    
     [self hyp_addKeyboardToolbarObservers];
 
     return self;


### PR DESCRIPTION
This resolves the crash presented in issue #559. It eliminates the crash by disabling bounces on the FORMViewController.

Note: This crash only occurs on iOS 10 so the underlying problem may be outside of Form.