### PR TITLE
Fix exception when enabling and running targets at the same time

### DIFF
--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -420,8 +420,10 @@ static const CGFloat FORMKeyboardAnimationDuration = 0.3f;
         }
     }
 
-    [UIView performWithoutAnimation:^{
-        [self.collectionView reloadItemsAtIndexPaths:[self.collectionView indexPathsForVisibleItems]];
+    [UIView animateWithDuration:0 animations:^{
+        [self.collectionView performBatchUpdates:^{
+            [self.collectionView reloadItemsAtIndexPaths:[self.collectionView indexPathsForVisibleItems]];
+        } completion:nil];
     }];
 
     [[NSNotificationCenter defaultCenter] postNotificationName:FORMHideTooltips
@@ -720,6 +722,14 @@ static const CGFloat FORMKeyboardAnimationDuration = 0.3f;
 }
 
 - (void)processTargets:(NSArray *)targets {
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_x_Max) {
+        [self performSelector:@selector(startProcessTargets:) withObject:targets afterDelay:0.01];
+    } else {
+        [self startProcessTargets:targets];
+    }
+}
+
+- (void)startProcessTargets:(NSArray *)targets {
     [FORMTarget filteredTargets:targets
                        filtered:^(NSArray *shownTargets,
                                   NSArray *hiddenTargets,

--- a/Source/FORMDataSource.m
+++ b/Source/FORMDataSource.m
@@ -723,6 +723,12 @@ static const CGFloat FORMKeyboardAnimationDuration = 0.3f;
 
 - (void)processTargets:(NSArray *)targets {
     if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_x_Max) {
+        /*
+         Fixes: https://github.com/hyperoslo/Form/issues/559
+         This resolves the crash presented in issue #559. I think is likely because the layout is computing different states at the same time, first the scrolling, then the enabling and then processing the targets, adding some delay fixes the issue. Also, it seems like `UIView performWithoutAnimation` wasn't working as it should, so I had to update that as well.
+
+         This crash only occurs on iOS 10.
+         */
         [self performSelector:@selector(startProcessTargets:) withObject:targets afterDelay:0.01];
     } else {
         [self startProcessTargets:targets];


### PR DESCRIPTION
This resolves the crash presented in issue #559. I think is likely because the layout is computing different states at the same time, first the scrolling, then the enabling and then processing the targets, adding some delay fixes the issue. Also, it seems like `UIView performWithoutAnimation` wasn't working as it should, so I had to update that as well.

This crash only occurs on iOS 10.