### PR TITLE
Hidden field order

### DIFF
--- a/Source/Cells/Switch/FORMSegmentFieldCell.m
+++ b/Source/Cells/Switch/FORMSegmentFieldCell.m
@@ -40,12 +40,16 @@ static NSString * const FORMSegmentBackgroundColorKey = @"background_color";
     self.segment.enabled = !field.disabled;
     self.disabled = field.disabled;
     
+    NSInteger *selectedIndex = [self.segment selectedSegmentIndex];
+    
     [self.segment removeAllSegments];
     
     [field.values enumerateObjectsUsingBlock:^(FORMFieldValue *value, NSUInteger index, BOOL *stop) {
         [self.segment insertSegmentWithTitle:value.title atIndex:index animated:NO];
 
-        if (value.defaultValue) {
+        if (selectedIndex || selectedIndex == 0) {
+            [self.segment setSelectedSegmentIndex:selectedIndex];
+        } else if (value.defaultValue) {
             [self.segment setSelectedSegmentIndex:index];
         }
     }];


### PR DESCRIPTION
This PR resolves an issue identified in #429. When fields are initially hidden and subsequently shown, they appear at the top of the section rather than their JSON defined arrangement.

This solution seems inelegant, but works -- which is why I'm requesting review.