### PR TITLE
Fix bug where date picker keeps reducing height when showing again

### DIFF
--- a/Source/Cells/Popover/FORMDateFieldCell.m
+++ b/Source/Cells/Popover/FORMDateFieldCell.m
@@ -184,7 +184,7 @@ static const CGSize FORMDatePhonePopoverSize = { 320.0f, 200.0f };
     if (self.field.info) {
         CGRect frame = self.datePicker.frame;
         frame.origin.y = 50.0f;
-        frame.size.height -= 25.0f;
+        frame.size.height = [self datePickerFrame].size.height - 25.0f;
         [self.datePicker setFrame:frame];
     }
 


### PR DESCRIPTION
In the demo project, if you click on a date field several times, the picker height will keep decreasing, and finally become totally hidden.
This line fixes this.